### PR TITLE
Equipment effects, inventory slots, combat spell picker

### DIFF
--- a/app/src/main/kotlin/com/realmsoffate/game/data/AutoTagUnknownNpcs.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/data/AutoTagUnknownNpcs.kt
@@ -14,6 +14,19 @@ object AutoTagUnknownNpcs {
         "After", "Before", "During", "Without", "Within", "Though", "Because"
     )
 
+    /** If the candidate's *last* word is an equipment/item category, it's an item, not an NPC. */
+    private val ITEM_TAIL_WORDS = setOf(
+        "sword", "shield", "armor", "armour", "helm", "helmet", "bow", "staff", "wand",
+        "ring", "amulet", "necklace", "cloak", "robe", "boots", "gauntlets", "gloves",
+        "dagger", "mace", "hammer", "spear", "axe", "blade", "knife", "lance", "pike",
+        "arrow", "arrows", "bolt", "bolts", "potion", "elixir", "scroll", "tome",
+        "book", "grimoire", "key", "gem", "stone", "crystal", "orb", "idol", "relic",
+        "talisman", "charm", "rod", "sceptre", "scepter", "crown", "circlet", "belt",
+        "buckler", "tunic", "mail", "plate", "greaves", "bracers", "pauldrons",
+        "crossbow", "longbow", "shortbow", "flail", "whip", "chain", "club", "cudgel",
+        "shuriken", "kunai", "javelin", "trident", "halberd", "glaive", "naginata"
+    )
+
     /** Two or three capitalized words, each >= 3 letters. */
     private val PROPER_NOUN = Regex("\\b([A-Z][a-z]{2,}(?: [A-Z][a-z]{2,}){1,2})\\b")
 
@@ -21,7 +34,9 @@ object AutoTagUnknownNpcs {
         parsed: ParsedReply,
         existingNpcs: List<LogNpc>,
         currentLoc: String,
-        turn: Int
+        turn: Int,
+        itemNames: Set<String> = emptySet(),
+        spellNames: Set<String> = emptySet()
     ): List<LogNpc> {
         val narrationText = parsed.segments.joinToString("\n") {
             when (it) {
@@ -35,13 +50,17 @@ object AutoTagUnknownNpcs {
         }
         if (narrationText.isBlank()) return emptyList()
         val existingKeys = existingNpcs.map { IdGen.nameKey(it.name) }.toSet()
+        val itemKeys = itemNames.map { IdGen.nameKey(it) }.toSet()
+        val spellKeys = spellNames.map { IdGen.nameKey(it) }.toSet()
         val out = mutableListOf<LogNpc>()
         val seenKeys = mutableSetOf<String>()
         for (m in PROPER_NOUN.findAll(narrationText)) {
             val name = m.groupValues[1]
             if (name.substringBefore(' ') in COMMON) continue
+            if (name.substringAfterLast(' ').lowercase() in ITEM_TAIL_WORDS) continue
             val key = IdGen.nameKey(name)
             if (key in existingKeys || key in seenKeys) continue
+            if (key in itemKeys || key in spellKeys) continue
             seenKeys += key
             out += LogNpc(
                 id = "",

--- a/app/src/main/kotlin/com/realmsoffate/game/data/EnvelopeParser.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/data/EnvelopeParser.kt
@@ -78,7 +78,7 @@ object EnvelopeParser {
             goldLost = meta.goldLost,
             itemsGained = meta.itemsGained
                 .filter { it.name.isNotBlank() }
-                .map { Item(name = it.name, desc = it.desc, type = it.type, rarity = it.rarity) },
+                .map { Item(name = it.name, desc = it.desc, type = it.type, rarity = it.rarity, effects = it.effects) },
             checks = check?.let {
                 listOf(CheckResult(it.skill, it.ability, it.dc, it.passed, it.total))
             } ?: emptyList(),

--- a/app/src/main/kotlin/com/realmsoffate/game/data/Models.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/data/Models.kt
@@ -32,8 +32,20 @@ data class Item(
     var qty: Int = 1,
     var equipped: Boolean = false,
     val damage: String? = null,
-    val ac: Int? = null
+    val ac: Int? = null,
+    val effects: List<ItemEffect> = emptyList()
 )
+
+@Serializable
+sealed interface ItemEffect {
+    @Serializable @SerialName("ability") data class AbilityBonus(val stat: String, val amount: Int) : ItemEffect
+    @Serializable @SerialName("skill")   data class SkillBonus(val skill: String, val amount: Int) : ItemEffect
+    @Serializable @SerialName("resist")  data class Resistance(val damageType: String) : ItemEffect
+    @Serializable @SerialName("immune")  data class Immunity(val damageType: String) : ItemEffect
+    @Serializable @SerialName("onhit")   data class OnHit(val dice: String, val damageType: String) : ItemEffect
+    @Serializable @SerialName("maxhp")   data class MaxHpBonus(val amount: Int) : ItemEffect
+    @Serializable @SerialName("trigger") data class PassiveTrigger(val text: String) : ItemEffect
+}
 
 @Serializable
 data class Backstory(
@@ -472,7 +484,8 @@ data class ItemSpec(
     val name: String = "",
     val desc: String = "",
     val type: String = "item",
-    val rarity: String = "common"
+    val rarity: String = "common",
+    val effects: List<ItemEffect> = emptyList()
 )
 
 @Serializable

--- a/app/src/main/kotlin/com/realmsoffate/game/data/Prompts.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/data/Prompts.kt
@@ -218,7 +218,7 @@ Every response MUST be exactly ONE valid JSON object. No markdown, no prose befo
   "metadata": {
     "damage": 0, "heal": 0, "xp": 0,
     "gold_gained": 0, "gold_lost": 0, "moral_delta": 0,
-    "items_gained": [{"name":"","desc":"","type":"weapon|armor|consumable|item","rarity":"common|uncommon|rare|epic|legendary"}],
+    "items_gained": [{"name":"","desc":"","type":"weapon|armor|shield|amulet|ring|clothes|consumable|item","rarity":"common|uncommon|rare|epic|legendary"}],
     "items_removed": [], "conditions_added": [], "conditions_removed": [],
     "npcs_met": [{"id":"slug","name":"Display","race":"","role":"","age":"","relationship":"neutral","appearance":"","personality":"","thoughts":""}],
     "npc_updates": [{"id":"slug","field":"relationship|role|faction|location|status|name","value":""}],

--- a/app/src/main/kotlin/com/realmsoffate/game/data/Prompts.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/data/Prompts.kt
@@ -218,7 +218,7 @@ Every response MUST be exactly ONE valid JSON object. No markdown, no prose befo
   "metadata": {
     "damage": 0, "heal": 0, "xp": 0,
     "gold_gained": 0, "gold_lost": 0, "moral_delta": 0,
-    "items_gained": [{"name":"","desc":"","type":"weapon|armor|shield|amulet|ring|clothes|consumable|item","rarity":"common|uncommon|rare|epic|legendary"}],
+    "items_gained": [{"name":"","desc":"","type":"weapon|armor|shield|amulet|ring|clothes|consumable|item","rarity":"common|uncommon|rare|epic|legendary","effects":[/* 0+ of: {"type":"ability","stat":"STR|DEX|CON|INT|WIS|CHA","amount":1} | {"type":"skill","skill":"Stealth","amount":2} | {"type":"resist","damageType":"fire"} | {"type":"immune","damageType":"poison"} | {"type":"onhit","dice":"1d4","damageType":"fire"} | {"type":"maxhp","amount":5} | {"type":"trigger","text":"cursed: -1 to all rolls"} */]}],
     "items_removed": [], "conditions_added": [], "conditions_removed": [],
     "npcs_met": [{"id":"slug","name":"Display","race":"","role":"","age":"","relationship":"neutral","appearance":"","personality":"","thoughts":""}],
     "npc_updates": [{"id":"slug","field":"relationship|role|faction|location|status|name","value":""}],
@@ -275,6 +275,13 @@ WORKED EXAMPLE (copy this shape exactly — notice everything is ONE JSON object
 }
 
 Mechanical side effects go in the "metadata" object — see the schema above for all available fields.
+
+EQUIPPED GEAR — honor the "Equipped gear:" block in the context:
+- Ability bonuses from equipped items are ALREADY folded into the STR/DEX/CON/INT/WIS/CHA scores shown. Do NOT re-apply them to checks or saves.
+- Skill-bonus effects (e.g. "+2 Stealth checks") are NOT folded in — add them to the relevant skill-check roll.
+- Resistances halve incoming damage of that type; immunities negate it entirely. Reflect that in "damage" values.
+- On-hit riders (e.g. "on hit: +1d6 fire") add their damage to successful weapon attacks — include the rider damage in the total.
+- Passive-trigger text is narrative law: honor it exactly as written while the item remains equipped.
 
 ZERO NUMBERS IN PROSE:
 BAD: {"kind":"prose","text":"The goblin's axe bites for 6 damage. You drop to 4/10 HP."}

--- a/app/src/main/kotlin/com/realmsoffate/game/game/Classes.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/game/Classes.kt
@@ -196,8 +196,6 @@ fun applyClassStart(ch: Character, cls: ClassDef) {
     ch.hp = ch.maxHp
     ch.inventory.clear()
     ch.inventory.addAll(cls.startingItems.map { it.copy() })
-    val acItem = ch.inventory.firstOrNull { it.equipped && it.ac != null }
-    ch.ac = (acItem?.ac ?: 10) + if (acItem?.name?.contains("Chain Mail") == true) 0 else ch.abilities.dexMod
-    if (ch.inventory.any { it.equipped && it.name.contains("Shield") }) ch.ac += 2
+    ch.ac = EquipmentEffects.effectiveAc(ch)
     if (cls.isCaster) Spells.grantStartingSpells(ch, cls)
 }

--- a/app/src/main/kotlin/com/realmsoffate/game/game/EquipmentEffects.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/game/EquipmentEffects.kt
@@ -73,4 +73,39 @@ object EquipmentEffects {
 
     fun passiveTriggers(ch: Character): List<String> =
         activeEffects(ch).filterIsInstance<ItemEffect.PassiveTrigger>().map { it.text }
+
+    fun promptSummary(ch: Character): String {
+        val eq = ch.inventory.filter { it.equipped }
+        val interesting = eq.filter { it.damage != null || it.ac != null || it.effects.isNotEmpty() }
+        val res = resistances(ch)
+        val imm = immunities(ch)
+        if (interesting.isEmpty() && res.isEmpty() && imm.isEmpty()) return ""
+        val sb = StringBuilder()
+        sb.appendLine("Equipped gear:")
+        interesting.forEach { item ->
+            sb.append("- ").append(item.name).append(" (").append(item.type)
+            if (item.damage != null) sb.append(", ").append(item.damage)
+            if (item.ac != null) sb.append(", AC ").append(item.ac)
+            sb.append(")")
+            val extras = mutableListOf<String>()
+            item.effects.forEach { e ->
+                when (e) {
+                    is ItemEffect.AbilityBonus -> extras.add("${signed(e.amount)} ${e.stat.uppercase()} (applied)")
+                    is ItemEffect.SkillBonus   -> extras.add("${signed(e.amount)} ${e.skill} checks")
+                    is ItemEffect.Resistance   -> { /* rolled up below */ }
+                    is ItemEffect.Immunity     -> { /* rolled up below */ }
+                    is ItemEffect.OnHit        -> extras.add("on hit: +${e.dice} ${e.damageType}")
+                    is ItemEffect.MaxHpBonus   -> extras.add("${signed(e.amount)} max HP")
+                    is ItemEffect.PassiveTrigger -> extras.add("passive: ${e.text}")
+                }
+            }
+            if (extras.isNotEmpty()) sb.append(" — ").append(extras.joinToString("; "))
+            sb.append('\n')
+        }
+        if (res.isNotEmpty()) sb.appendLine("Resistances: ${res.sorted().joinToString(", ")}")
+        if (imm.isNotEmpty()) sb.appendLine("Immunities: ${imm.sorted().joinToString(", ")}")
+        return sb.toString().trimEnd()
+    }
+
+    private fun signed(n: Int): String = if (n >= 0) "+$n" else "$n"
 }

--- a/app/src/main/kotlin/com/realmsoffate/game/game/EquipmentEffects.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/game/EquipmentEffects.kt
@@ -1,0 +1,33 @@
+package com.realmsoffate.game.game
+
+import com.realmsoffate.game.data.Abilities
+import com.realmsoffate.game.data.Character
+import com.realmsoffate.game.data.ItemEffect
+
+object EquipmentEffects {
+
+    fun activeEffects(ch: Character): List<ItemEffect> =
+        ch.inventory.filter { it.equipped }.flatMap { it.effects }
+
+    fun effectiveAbilities(ch: Character): Abilities {
+        var str = ch.abilities.str
+        var dex = ch.abilities.dex
+        var con = ch.abilities.con
+        var int = ch.abilities.int
+        var wis = ch.abilities.wis
+        var cha = ch.abilities.cha
+        activeEffects(ch).forEach { e ->
+            if (e is ItemEffect.AbilityBonus) {
+                when (e.stat.uppercase()) {
+                    "STR" -> str += e.amount
+                    "DEX" -> dex += e.amount
+                    "CON" -> con += e.amount
+                    "INT" -> int += e.amount
+                    "WIS" -> wis += e.amount
+                    "CHA" -> cha += e.amount
+                }
+            }
+        }
+        return Abilities(str, dex, con, int, wis, cha)
+    }
+}

--- a/app/src/main/kotlin/com/realmsoffate/game/game/EquipmentEffects.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/game/EquipmentEffects.kt
@@ -30,4 +30,19 @@ object EquipmentEffects {
         }
         return Abilities(str, dex, con, int, wis, cha)
     }
+
+    private val HEAVY_ARMOR_TOKENS = listOf("Chain Mail", "Plate", "Ring Mail", "Splint")
+
+    fun effectiveAc(ch: Character): Int {
+        val eq = ch.inventory.filter { it.equipped }
+        val armor = eq.firstOrNull { it.ac != null }
+        val hasShield = eq.any { it.type.equals("shield", ignoreCase = true) }
+        val effDex = effectiveAbilities(ch).dexMod
+        val base = when {
+            armor == null -> 10 + effDex
+            HEAVY_ARMOR_TOKENS.any { armor.name.contains(it, ignoreCase = true) } -> armor.ac!!
+            else -> armor.ac!! + effDex
+        }
+        return base + if (hasShield) 2 else 0
+    }
 }

--- a/app/src/main/kotlin/com/realmsoffate/game/game/EquipmentEffects.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/game/EquipmentEffects.kt
@@ -108,4 +108,20 @@ object EquipmentEffects {
     }
 
     private fun signed(n: Int): String = if (n >= 0) "+$n" else "$n"
+
+    /**
+     * Given the character before and after an equip-state change, return the
+     * (newMaxHp, newHp) pair. Uses the MaxHpBonus delta so base maxHp is
+     * preserved; never heals on equip; clamps down on unequip.
+     */
+    fun recalcHpAfterEquip(oldChar: Character, newChar: Character): Pair<Int, Int> {
+        val oldBonus = oldChar.inventory.filter { it.equipped }
+            .flatMap { it.effects }.filterIsInstance<ItemEffect.MaxHpBonus>().sumOf { it.amount }
+        val newBonus = newChar.inventory.filter { it.equipped }
+            .flatMap { it.effects }.filterIsInstance<ItemEffect.MaxHpBonus>().sumOf { it.amount }
+        val delta = newBonus - oldBonus
+        val newMax = (oldChar.maxHp + delta).coerceAtLeast(1)
+        val newHp = oldChar.hp.coerceAtMost(newMax)
+        return newMax to newHp
+    }
 }

--- a/app/src/main/kotlin/com/realmsoffate/game/game/EquipmentEffects.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/game/EquipmentEffects.kt
@@ -45,4 +45,32 @@ object EquipmentEffects {
         }
         return base + if (hasShield) 2 else 0
     }
+
+    fun effectiveMaxHp(ch: Character): Int =
+        ch.maxHp + activeEffects(ch).filterIsInstance<ItemEffect.MaxHpBonus>().sumOf { it.amount }
+
+    fun skillBonuses(ch: Character): Map<String, Int> {
+        val out = LinkedHashMap<String, Int>()
+        activeEffects(ch).filterIsInstance<ItemEffect.SkillBonus>().forEach { e ->
+            val trimmed = e.skill.trim()
+            val key = if (trimmed.isEmpty()) ""
+                else trimmed[0].uppercaseChar() + trimmed.substring(1).lowercase()
+            out[key] = (out[key] ?: 0) + e.amount
+        }
+        return out
+    }
+
+    fun resistances(ch: Character): Set<String> =
+        activeEffects(ch).filterIsInstance<ItemEffect.Resistance>()
+            .map { it.damageType.lowercase() }.toSet()
+
+    fun immunities(ch: Character): Set<String> =
+        activeEffects(ch).filterIsInstance<ItemEffect.Immunity>()
+            .map { it.damageType.lowercase() }.toSet()
+
+    fun onHitRiders(ch: Character): List<ItemEffect.OnHit> =
+        activeEffects(ch).filterIsInstance<ItemEffect.OnHit>()
+
+    fun passiveTriggers(ch: Character): List<String> =
+        activeEffects(ch).filterIsInstance<ItemEffect.PassiveTrigger>().map { it.text }
 }

--- a/app/src/main/kotlin/com/realmsoffate/game/game/GameViewModel.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/game/GameViewModel.kt
@@ -420,7 +420,8 @@ class GameViewModel(
             if (ch != null) {
                 appendLine("Name: ${ch.name}  Race: ${ch.race}  Class: ${ch.cls}  Level: ${ch.level}")
                 appendLine("HP: ${ch.hp}/${ch.maxHp}  AC: ${ch.ac}  Gold: ${ch.gold}  XP: ${ch.xp}")
-                appendLine("STR:${ch.abilities.str} DEX:${ch.abilities.dex} CON:${ch.abilities.con} INT:${ch.abilities.int} WIS:${ch.abilities.wis} CHA:${ch.abilities.cha}")
+                val effAb = EquipmentEffects.effectiveAbilities(ch)
+                appendLine("STR:${effAb.str} DEX:${effAb.dex} CON:${effAb.con} INT:${effAb.int} WIS:${effAb.wis} CHA:${effAb.cha}")
                 appendLine("Proficiency: +${ch.proficiency}")
                 appendLine("Conditions: ${ch.conditions.joinToString(", ").ifBlank { "none" }}")
                 appendLine("Feats: ${ch.feats.joinToString(", ").ifBlank { "none" }}")
@@ -830,7 +831,7 @@ class GameViewModel(
                 val effectiveSkill = classified ?: "Perception"
                 val roll = Dice.d20()
                 val ability = if (effectiveSkill == "Attack") "STR" else skillToAbility(effectiveSkill)
-                val mod = char.abilities.modByName(ability)
+                val mod = EquipmentEffects.effectiveAbilities(char).modByName(ability)
                 val prof = if (classProficient(char.cls, effectiveSkill)) char.proficiency else 0
                 val total = roll + mod + prof
                 _ui.value = _ui.value.copy(
@@ -854,7 +855,7 @@ class GameViewModel(
         // is deferred until the player taps Send It on the dice breakdown.
         val roll = Dice.d20()
         val ability = skillToAbility(skill)
-        val mod = char.abilities.modByName(ability)
+        val mod = EquipmentEffects.effectiveAbilities(char).modByName(ability)
         val prof = if (classProficient(char.cls, skill)) char.proficiency else 0
         val total = roll + mod + prof
         _ui.value = _ui.value.copy(
@@ -910,7 +911,7 @@ class GameViewModel(
 
             val roll = preRolled
             val ability = skill?.let { skillToAbility(it) } ?: "STR"
-            val mod = char.abilities.modByName(ability)
+            val mod = EquipmentEffects.effectiveAbilities(char).modByName(ability)
             val prof = if (skill != null && classProficient(char.cls, skill)) char.proficiency else 0
             val total = roll + mod + prof
 

--- a/app/src/main/kotlin/com/realmsoffate/game/game/GameViewModel.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/game/GameViewModel.kt
@@ -1625,6 +1625,10 @@ class GameViewModel(
         _ui.value = s.copy(hotbar = hb)
     }
 
+    fun useConsumable(item: Item) {
+        submitAction("I use ${item.name}")
+    }
+
     fun equipToggle(item: Item) {
         val s = _ui.value
         val ch = s.character ?: return

--- a/app/src/main/kotlin/com/realmsoffate/game/game/GameViewModel.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/game/GameViewModel.kt
@@ -1626,7 +1626,18 @@ class GameViewModel(
     }
 
     fun useConsumable(item: Item) {
-        submitAction("I use ${item.name}")
+        val s = _ui.value
+        val ch = s.character
+        if (ch != null) {
+            val inv = ch.inventory.toMutableList()
+            val idx = inv.indexOfFirst { it.name.equals(item.name, true) }
+            if (idx >= 0) {
+                val e = inv[idx]
+                if (e.qty > 1) inv[idx] = e.copy(qty = e.qty - 1) else inv.removeAt(idx)
+                _ui.value = s.copy(character = ch.copy(inventory = inv))
+            }
+        }
+        submitAction("I use my ${item.name}")
     }
 
     fun equipToggle(item: Item) {
@@ -1635,8 +1646,11 @@ class GameViewModel(
         val inv = ch.inventory.toMutableList()
         val idx = inv.indexOfFirst { it.name == item.name }
         if (idx < 0) return
-        inv[idx] = inv[idx].copy(equipped = !inv[idx].equipped)
+        val nowEquipped = !inv[idx].equipped
+        inv[idx] = inv[idx].copy(equipped = nowEquipped)
         _ui.value = s.copy(character = ch.copy(inventory = inv))
+        val verb = if (nowEquipped) "equip" else "unequip"
+        submitAction("I $verb my ${item.name}")
     }
 
     fun dismissCompanion(name: String) {

--- a/app/src/main/kotlin/com/realmsoffate/game/game/GameViewModel.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/game/GameViewModel.kt
@@ -1651,10 +1651,7 @@ class GameViewModel(
         if (nowEquipped) {
             val itemType = inv[idx].type
             val slotLimit = if (itemType == "ring") 2 else 1
-            val groupTypes: Set<String> = when (itemType) {
-                "armor", "shield" -> setOf("armor", "shield")
-                else -> setOf(itemType)
-            }
+            val groupTypes: Set<String> = setOf(itemType)
             val equippedInGroup = inv.withIndex()
                 .filter { (i, e) -> i != idx && e.equipped && e.type in groupTypes }
             val overflow = (equippedInGroup.size + 1) - slotLimit

--- a/app/src/main/kotlin/com/realmsoffate/game/game/GameViewModel.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/game/GameViewModel.kt
@@ -1647,10 +1647,32 @@ class GameViewModel(
         val idx = inv.indexOfFirst { it.name == item.name }
         if (idx < 0) return
         val nowEquipped = !inv[idx].equipped
+        val displaced = mutableListOf<String>()
+        if (nowEquipped) {
+            val itemType = inv[idx].type
+            val slotLimit = if (itemType == "ring") 2 else 1
+            val groupTypes: Set<String> = when (itemType) {
+                "armor", "shield" -> setOf("armor", "shield")
+                else -> setOf(itemType)
+            }
+            val equippedInGroup = inv.withIndex()
+                .filter { (i, e) -> i != idx && e.equipped && e.type in groupTypes }
+            val overflow = (equippedInGroup.size + 1) - slotLimit
+            if (overflow > 0) {
+                equippedInGroup.take(overflow).forEach { (i, e) ->
+                    inv[i] = e.copy(equipped = false)
+                    displaced += e.name
+                }
+            }
+        }
         inv[idx] = inv[idx].copy(equipped = nowEquipped)
         _ui.value = s.copy(character = ch.copy(inventory = inv))
-        val verb = if (nowEquipped) "equip" else "unequip"
-        submitAction("I $verb my ${item.name}")
+        val action = when {
+            !nowEquipped -> "I unequip my ${item.name}"
+            displaced.isEmpty() -> "I equip my ${item.name}"
+            else -> "I unequip my ${displaced.joinToString(" and ")} and equip my ${item.name}"
+        }
+        submitAction(action)
     }
 
     fun dismissCompanion(name: String) {

--- a/app/src/main/kotlin/com/realmsoffate/game/game/GameViewModel.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/game/GameViewModel.kt
@@ -1432,7 +1432,9 @@ class GameViewModel(
             parsed = parsed,
             existingNpcs = state.npcLog,
             currentLoc = currentLocNameForParse,
-            turn = state.turns + 1
+            turn = state.turns + 1,
+            itemNames = state.character?.inventory?.map { it.name }?.toSet().orEmpty(),
+            spellNames = state.character?.knownSpells?.toSet().orEmpty()
         )
         val parsedAugmented = if (autoTagged.isEmpty()) parsed
         else parsed.copy(npcsMet = parsed.npcsMet + autoTagged)
@@ -1663,7 +1665,10 @@ class GameViewModel(
             }
         }
         inv[idx] = inv[idx].copy(equipped = nowEquipped)
-        _ui.value = s.copy(character = ch.copy(inventory = inv))
+        val staged = ch.copy(inventory = inv)
+        val (newMaxHp, newHp) = EquipmentEffects.recalcHpAfterEquip(oldChar = ch, newChar = staged)
+        val newAc = EquipmentEffects.effectiveAc(staged)
+        _ui.value = s.copy(character = staged.copy(maxHp = newMaxHp, hp = newHp, ac = newAc))
         val action = when {
             !nowEquipped -> "I unequip my ${item.name}"
             displaced.isEmpty() -> "I equip my ${item.name}"

--- a/app/src/main/kotlin/com/realmsoffate/game/game/GameViewModel.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/game/GameViewModel.kt
@@ -425,7 +425,9 @@ class GameViewModel(
                 appendLine("Proficiency: +${ch.proficiency}")
                 appendLine("Conditions: ${ch.conditions.joinToString(", ").ifBlank { "none" }}")
                 appendLine("Feats: ${ch.feats.joinToString(", ").ifBlank { "none" }}")
-                appendLine("Equipped: ${ch.inventory.filter { it.equipped }.joinToString(", ") { it.name }.ifBlank { "nothing" }}")
+                val gearSummary = EquipmentEffects.promptSummary(ch)
+                if (gearSummary.isBlank()) appendLine("Equipped: nothing")
+                else { appendLine(); appendLine(gearSummary) }
                 appendLine("Inventory: ${ch.inventory.joinToString(", ") { "${it.name}(x${it.qty})" }.ifBlank { "empty" }}")
                 ch.backstory?.let {
                     appendLine("Backstory: origin=${it.origin}, flaw=${it.flaw}, bond=${it.bond}")
@@ -1178,7 +1180,7 @@ class GameViewModel(
             .joinToString("\n") { "${it.name} (${it.race} ${it.role})" }
             .let { if (it.isNotBlank()) "\nNPCs HERE:\n$it" else "" }
 
-        val inv = ch.inventory.filter { it.equipped }.joinToString(", ") { it.name }.ifBlank { "nothing" }
+        val inv = EquipmentEffects.promptSummary(ch).ifBlank { "Equipped: nothing" }
         val invAll = ch.inventory.joinToString(", ") { "${it.name} (x${it.qty})" }
 
         val currentLocName = s.worldMap?.locations?.getOrNull(s.currentLoc)?.name ?: ""
@@ -1236,7 +1238,7 @@ class GameViewModel(
             append("\nNEARBY: ${nearby.joinToString(", ") { "${it.first.name} (${it.second}lg)" }}")
             append("\nTURN: ${s.turns + 1}")
             append(partyCtx); append(questCtx); append(npcCtx); append(knownNpcsCtx); append(eventCtx)
-            append("\nEquipped: $inv")
+            append("\n").append(inv)
             append("\nInventory: ${invAll.ifBlank { "empty" }}")
             // Long-term memory: arcs (matched first, then newest to fill), then
             // scene summaries (recent working set), then keyword-matched past scenes

--- a/app/src/main/kotlin/com/realmsoffate/game/ui/game/CharacterPager.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/ui/game/CharacterPager.kt
@@ -27,6 +27,7 @@ private enum class CharacterTab(val label: String) {
 internal fun CharacterPager(
     state: GameUiState,
     onEquip: (Item) -> Unit,
+    onUse: (Item) -> Unit,
     onDismiss: (String) -> Unit,
     onHotbar: (Int, String?) -> Unit,
     onCast: (Spell) -> Unit
@@ -50,7 +51,7 @@ internal fun CharacterPager(
             Column(mod) {
                 when (tabs[page]) {
                     CharacterTab.Stats -> StatsContent(state)
-                    CharacterTab.Inventory -> InventoryContent(state, onEquip)
+                    CharacterTab.Inventory -> InventoryContent(state, onEquip, onUse)
                     CharacterTab.Spells -> SpellsContent(state, onHotbar, onCast)
                     CharacterTab.Party -> PartyContent(state, onDismiss)
                 }

--- a/app/src/main/kotlin/com/realmsoffate/game/ui/game/GameScreen.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/ui/game/GameScreen.kt
@@ -21,6 +21,7 @@ import com.realmsoffate.game.ui.overlays.CheatsOverlay
 import com.realmsoffate.game.ui.overlays.FeatSelectionOverlay
 import com.realmsoffate.game.ui.overlays.InitiativeOverlay
 import com.realmsoffate.game.ui.overlays.LevelUpOverlay
+import com.realmsoffate.game.ui.overlays.SpellPickerSheet
 import com.realmsoffate.game.ui.overlays.TargetPromptDialog
 import com.realmsoffate.game.ui.overlays.TargetPromptSpec
 import com.realmsoffate.game.ui.panels.*
@@ -40,6 +41,7 @@ fun GameScreen(vm: GameViewModel) {
     var journalFocusNpc by remember { mutableStateOf<String?>(null) }
     var tab by remember { mutableStateOf(GameTab.Chat) }
     var choicesOpen by remember { mutableStateOf(false) }
+    var spellPickerOpen by remember { mutableStateOf(false) }
     var input by remember { mutableStateOf("") }
     val focus = LocalFocusManager.current
     val listState = rememberLazyListState()
@@ -156,7 +158,7 @@ fun GameScreen(vm: GameViewModel) {
                             }
                         },
                         onTargetPrompt = { vm.requestTargetPrompt(it) },
-                        onSpellsOpen = { panel = Panel.Spells },
+                        onSpellsOpen = { spellPickerOpen = true },
                         hasChoices = state.currentChoices.isNotEmpty(),
                         onChoicesOpen = { choicesOpen = true }
                     )
@@ -284,6 +286,38 @@ fun GameScreen(vm: GameViewModel) {
     val showInitiative by vm.showInitiative.collectAsState()
     if (showInitiative) {
         InitiativeOverlay(onDismiss = { vm.dismissInitiative() })
+    }
+
+    if (spellPickerOpen) {
+        state.character?.let { ch ->
+            SpellPickerSheet(
+                character = ch,
+                onCast = { spell ->
+                    spellPickerOpen = false
+                    val activeCombat = state.combat
+                    val recentTargets = if (activeCombat != null) {
+                        activeCombat.order
+                            .filter { !it.isPlayer }
+                            .map { it.name }
+                            .distinct()
+                            .take(8)
+                    } else emptyList()
+                    if (isSelfCastable(spell)) {
+                        vm.submitAction("I cast ${spell.name} on myself")
+                    } else {
+                        vm.requestTargetPrompt(
+                            TargetPromptSpec(
+                                title = "Cast ${spell.name}",
+                                verb = "I cast ${spell.name} at",
+                                selfCastable = isSelfCastable(spell),
+                                recentTargets = recentTargets
+                            )
+                        )
+                    }
+                },
+                onDismiss = { spellPickerOpen = false }
+            )
+        } ?: run { spellPickerOpen = false }
     }
 
     val targetPrompt by vm.targetPrompt.collectAsState()

--- a/app/src/main/kotlin/com/realmsoffate/game/ui/game/GameScreen.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/ui/game/GameScreen.kt
@@ -201,7 +201,10 @@ fun GameScreen(vm: GameViewModel) {
                 GameTab.Character -> {
                     CharacterPager(
                         state = state,
-                        onEquip = vm::equipToggle,
+                        onEquip = { item ->
+                            tab = GameTab.Chat
+                            vm.equipToggle(item)
+                        },
                         onUse = { item ->
                             tab = GameTab.Chat
                             vm.useConsumable(item)

--- a/app/src/main/kotlin/com/realmsoffate/game/ui/game/GameScreen.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/ui/game/GameScreen.kt
@@ -202,6 +202,10 @@ fun GameScreen(vm: GameViewModel) {
                     CharacterPager(
                         state = state,
                         onEquip = vm::equipToggle,
+                        onUse = { item ->
+                            tab = GameTab.Chat
+                            vm.useConsumable(item)
+                        },
                         onDismiss = vm::dismissCompanion,
                         onHotbar = vm::updateHotbar,
                         onCast = { spell ->

--- a/app/src/main/kotlin/com/realmsoffate/game/ui/overlays/SpellPickerSheet.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/ui/overlays/SpellPickerSheet.kt
@@ -1,0 +1,192 @@
+package com.realmsoffate.game.ui.overlays
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.realmsoffate.game.data.Character
+import com.realmsoffate.game.game.Spell
+import com.realmsoffate.game.game.Spells
+import com.realmsoffate.game.ui.components.RealmsCard
+import com.realmsoffate.game.ui.theme.RealmsSpacing
+
+private val spellLevelLabels = mapOf(
+    0 to "CANTRIPS & ABILITIES",
+    1 to "1ST LEVEL",
+    2 to "2ND LEVEL",
+    3 to "3RD LEVEL",
+    4 to "4TH LEVEL",
+    5 to "5TH LEVEL"
+)
+
+/**
+ * Combat-time spell picker. Mirrors the Attack button's ModalBottomSheet
+ * pattern: bottom-anchored sheet that lists the character's known spells
+ * grouped by level. Tapping a castable spell dismisses the sheet and fires
+ * [onCast]; the caller routes into the target prompt or self-cast flow.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SpellPickerSheet(
+    character: Character,
+    onCast: (Spell) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val sheet = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val known = remember(character) {
+        character.knownSpells.mapNotNull { Spells.find(it) }.sortedBy { it.level }
+    }
+    val grouped = remember(known) { known.groupBy { it.level } }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheet,
+        shape = MaterialTheme.shapes.extraLarge
+    ) {
+        Column(Modifier.padding(horizontal = RealmsSpacing.xl, vertical = RealmsSpacing.s)) {
+            Text(
+                "CAST A SPELL",
+                style = MaterialTheme.typography.labelLarge.copy(letterSpacing = 3.sp),
+                color = MaterialTheme.colorScheme.primary
+            )
+            Spacer(Modifier.height(RealmsSpacing.xs))
+            SlotStrip(character)
+
+            if (known.isEmpty()) {
+                Spacer(Modifier.height(RealmsSpacing.m))
+                Text(
+                    "You know no spells.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            } else {
+                Spacer(Modifier.height(RealmsSpacing.s))
+                LazyColumn(
+                    Modifier.heightIn(max = 420.dp),
+                    verticalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    grouped.keys.sorted().forEach { lvl ->
+                        item {
+                            Text(
+                                spellLevelLabels[lvl] ?: "LEVEL $lvl",
+                                style = MaterialTheme.typography.labelLarge.copy(letterSpacing = 2.sp),
+                                color = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.padding(top = 6.dp, bottom = 2.dp)
+                            )
+                        }
+                        items(grouped[lvl].orEmpty()) { spell ->
+                            val canCast = spell.level == 0 ||
+                                (character.spellSlots[spell.level] ?: 0) > 0
+                            SpellRow(spell, canCast) {
+                                if (canCast) onCast(spell)
+                            }
+                        }
+                    }
+                }
+            }
+            Spacer(Modifier.height(RealmsSpacing.s))
+            OutlinedButton(
+                onClick = onDismiss,
+                modifier = Modifier.fillMaxWidth()
+            ) { Text("Cancel") }
+            Spacer(Modifier.navigationBarsPadding().height(RealmsSpacing.m))
+        }
+    }
+}
+
+@Composable
+private fun SlotStrip(ch: Character) {
+    val levels = ch.maxSpellSlots.keys.sorted()
+    if (levels.isEmpty()) return
+    Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+        levels.forEach { lvl ->
+            val max = ch.maxSpellSlots[lvl] ?: 0
+            val cur = ch.spellSlots[lvl] ?: 0
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(
+                    "L$lvl",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    fontWeight = FontWeight.Bold
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(2.dp)) {
+                    repeat(max) { i ->
+                        SlotDiamond(filled = i < cur, color = MaterialTheme.colorScheme.secondary)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SlotDiamond(filled: Boolean, color: Color) {
+    Box(
+        Modifier
+            .size(10.dp)
+            .rotate(45f)
+            .background(
+                if (filled) color else Color.Transparent,
+                RoundedCornerShape(1.dp)
+            )
+            .border(1.dp, color, RoundedCornerShape(1.dp))
+    )
+}
+
+@Composable
+private fun SpellRow(
+    spell: Spell,
+    canCast: Boolean,
+    onClick: () -> Unit
+) {
+    RealmsCard(
+        onClick = onClick,
+        shape = MaterialTheme.shapes.medium,
+        outlined = true,
+        accentColor = if (canCast) MaterialTheme.colorScheme.outlineVariant
+                      else MaterialTheme.colorScheme.error.copy(alpha = 0.4f),
+        contentPadding = RealmsSpacing.s,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(spell.icon, style = MaterialTheme.typography.titleLarge)
+            Spacer(Modifier.width(10.dp))
+            Column(Modifier.weight(1f)) {
+                Text(
+                    spell.name,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Medium,
+                    maxLines = 1
+                )
+                Text(
+                    buildString {
+                        append(spell.school)
+                        if (spell.level > 0) append(" · L${spell.level}")
+                        if (spell.damage != "-") append(" · ${spell.damage}")
+                    },
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1
+                )
+            }
+            if (!canCast) {
+                Text(
+                    "No slots",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/realmsoffate/game/ui/panels/InventoryPage.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/ui/panels/InventoryPage.kt
@@ -1,11 +1,10 @@
 package com.realmsoffate.game.ui.panels
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -15,25 +14,26 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.realmsoffate.game.data.Item
 import com.realmsoffate.game.game.GameUiState
 import com.realmsoffate.game.ui.components.EmptyState
 import com.realmsoffate.game.ui.components.PanelSheet
 import com.realmsoffate.game.ui.components.RealmsCard
-import com.realmsoffate.game.ui.components.SectionHeader
 import com.realmsoffate.game.ui.theme.RealmsSpacing
 import com.realmsoffate.game.ui.theme.RealmsTheme
 
 // ----------------- INVENTORY (equipped slots + 5-col backpack grid) -----------------
 
 @Composable
-internal fun InventoryContent(state: GameUiState, onEquip: (Item) -> Unit) {
+internal fun InventoryContent(state: GameUiState, onEquip: (Item) -> Unit, onUse: (Item) -> Unit) {
     val ch = state.character ?: return
     var selected by remember(ch) { mutableStateOf<Item?>(null) }
     // ---- Equipped slots (2 col) ----
     val weapon = ch.inventory.firstOrNull { it.equipped && it.type == "weapon" }
     val armor = ch.inventory.firstOrNull { it.equipped && (it.type == "armor" || it.type == "shield") }
+    val equippedNames = listOfNotNull(weapon?.name, armor?.name)
+    val selectedIsEquipped = selected?.name in equippedNames
+    InventorySectionHeader("EQUIPMENT")
     Row(
         Modifier.padding(horizontal = RealmsSpacing.l).fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(8.dp)
@@ -53,21 +53,21 @@ internal fun InventoryContent(state: GameUiState, onEquip: (Item) -> Unit) {
             modifier = Modifier.weight(1f)
         )
     }
-    // ---- Selected item detail card ----
-    selected?.let { item ->
+    if (selectedIsEquipped) {
         Spacer(Modifier.height(8.dp))
-        SelectedItemCard(
-            item = item,
-            onEquipToggle = { onEquip(item); selected = item.copy(equipped = !item.equipped) },
-            onUse = {
-                // Consumables route through onEquip for now (a "use" hook would live on the VM).
-                onEquip(item); selected = null
-            }
-        )
+        Box(Modifier.padding(horizontal = RealmsSpacing.l)) {
+            SelectedItemCard(
+                item = selected!!,
+                onEquipToggle = {
+                    val i = selected!!
+                    onEquip(i); selected = i.copy(equipped = !i.equipped)
+                },
+                onUse = { val i = selected!!; onUse(i); selected = null }
+            )
+        }
     }
-    // ---- Backpack grid (5 col) ----
-    Spacer(Modifier.height(10.dp))
-    SectionHeader("  BACKPACK")
+    // ---- Backpack grid (2 col; detail card appears inline under the tapped row) ----
+    InventorySectionHeader("BACKPACK")
     val backpack = ch.inventory.filter { !(it.equipped && it.type in setOf("weapon", "armor", "shield")) }
     if (backpack.isEmpty()) {
         Text(
@@ -78,32 +78,70 @@ internal fun InventoryContent(state: GameUiState, onEquip: (Item) -> Unit) {
         )
         return
     }
+    val cols = 2
+    val rows = backpack.chunked(cols)
     LazyVerticalGrid(
-        columns = GridCells.Fixed(5),
-        verticalArrangement = Arrangement.spacedBy(6.dp),
-        horizontalArrangement = Arrangement.spacedBy(6.dp),
-        modifier = Modifier.padding(horizontal = RealmsSpacing.m).heightIn(max = 380.dp)
+        columns = GridCells.Fixed(cols),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier.padding(horizontal = RealmsSpacing.l).heightIn(max = 520.dp)
     ) {
-        items(backpack) { item ->
-            BackpackCell(
-                item = item,
-                selected = selected?.name == item.name,
-                onClick = { selected = item }
-            )
+        rows.forEach { row ->
+            row.forEach { bpItem ->
+                item(key = "cell-${bpItem.name}") {
+                    BackpackCell(
+                        item = bpItem,
+                        selected = selected?.name == bpItem.name,
+                        onClick = { selected = bpItem }
+                    )
+                }
+            }
+            repeat(cols - row.size) { idx ->
+                item(key = "pad-${row.first().name}-$idx") {}
+            }
+            val selInRow = selected != null && row.any { it.name == selected!!.name }
+            if (selInRow) {
+                item(
+                    key = "detail-${selected!!.name}",
+                    span = { GridItemSpan(maxLineSpan) }
+                ) {
+                    SelectedItemCard(
+                        item = selected!!,
+                        onEquipToggle = {
+                            val i = selected!!
+                            onEquip(i); selected = i.copy(equipped = !i.equipped)
+                        },
+                        onUse = { val i = selected!!; onUse(i); selected = null }
+                    )
+                }
+            }
         }
     }
 }
 
 @Composable
-internal fun InventoryPanel(state: GameUiState, onClose: () -> Unit, onEquip: (Item) -> Unit) {
+internal fun InventoryPanel(state: GameUiState, onClose: () -> Unit, onEquip: (Item) -> Unit, onUse: (Item) -> Unit) {
     val ch = state.character
     PanelSheet(
         "\uD83C\uDF92  Inventory",
         subtitle = if (ch == null || ch.inventory.isEmpty()) null else "${ch.inventory.size} items",
         onClose = onClose
     ) {
-        InventoryContent(state, onEquip)
+        InventoryContent(state, onEquip, onUse)
     }
+}
+
+@Composable
+private fun InventorySectionHeader(text: String) {
+    Text(
+        text,
+        style = MaterialTheme.typography.labelLarge,
+        color = MaterialTheme.colorScheme.primary,
+        textAlign = TextAlign.Center,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = RealmsSpacing.s)
+    )
 }
 
 @Composable
@@ -157,7 +195,7 @@ private fun SelectedItemCard(item: Item, onEquipToggle: () -> Unit, onUse: () ->
         accentColor = color,
         shape = MaterialTheme.shapes.medium,
         contentPadding = RealmsSpacing.m,
-        modifier = Modifier.padding(horizontal = RealmsSpacing.l).fillMaxWidth()
+        modifier = Modifier.fillMaxWidth()
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Box(
@@ -205,55 +243,58 @@ private fun SelectedItemCard(item: Item, onEquipToggle: () -> Unit, onUse: () ->
 @Composable
 private fun BackpackCell(item: Item, selected: Boolean, onClick: () -> Unit) {
     val color = rarityColor(item.rarity)
-    Surface(
+    RealmsCard(
         onClick = onClick,
-        color = if (selected) color.copy(alpha = 0.16f) else MaterialTheme.colorScheme.surfaceContainer,
-        shape = MaterialTheme.shapes.small,
-        modifier = Modifier.aspectRatio(0.85f).border(
-            1.dp,
-            if (selected) color else color.copy(alpha = 0.25f),
-            MaterialTheme.shapes.small
-        )
+        shape = MaterialTheme.shapes.medium,
+        outlined = true,
+        accentColor = color,
+        selected = selected,
+        contentPadding = RealmsSpacing.m,
+        modifier = Modifier.fillMaxWidth()
     ) {
-        Box(Modifier.fillMaxSize()) {
-            Column(
-                Modifier.fillMaxSize().padding(4.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center
-            ) {
-                Text(itemIconFor(item), style = MaterialTheme.typography.titleMedium)
-                Spacer(Modifier.height(2.dp))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                item.type.uppercase(),
+                style = MaterialTheme.typography.labelSmall,
+                color = color,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.weight(1f),
+                maxLines = 1
+            )
+            if (item.qty > 1) {
                 Text(
-                    item.name,
-                    style = MaterialTheme.typography.labelSmall.copy(fontSize = 9.sp),
-                    color = MaterialTheme.colorScheme.onSurface,
-                    maxLines = 2,
-                    textAlign = TextAlign.Center
+                    "×${item.qty}",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontWeight = FontWeight.Bold
                 )
             }
-            if (item.qty > 1) {
-                Surface(
-                    color = MaterialTheme.colorScheme.primary,
-                    shape = MaterialTheme.shapes.extraSmall,
-                    modifier = Modifier.align(Alignment.TopEnd).padding(2.dp)
-                ) {
+        }
+        Spacer(Modifier.height(4.dp))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(itemIconFor(item), style = MaterialTheme.typography.titleLarge)
+            Spacer(Modifier.width(8.dp))
+            Column(Modifier.weight(1f)) {
+                Text(
+                    item.name,
+                    style = MaterialTheme.typography.titleSmall,
+                    maxLines = 1
+                )
+                val sub = when {
+                    item.ac != null -> "AC ${item.ac}"
+                    item.damage != null -> item.damage
+                    item.equipped -> "equipped"
+                    else -> null
+                }
+                if (sub != null) {
                     Text(
-                        "${item.qty}",
-                        style = MaterialTheme.typography.labelSmall.copy(fontSize = 8.sp),
-                        color = MaterialTheme.colorScheme.onPrimary,
-                        fontWeight = FontWeight.Bold,
-                        modifier = Modifier.padding(horizontal = 4.dp, vertical = 1.dp)
+                        sub,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1
                     )
                 }
             }
-            // Rarity color bar at the bottom.
-            Box(
-                Modifier
-                    .align(Alignment.BottomCenter)
-                    .fillMaxWidth()
-                    .height(2.dp)
-                    .background(color)
-            )
         }
     }
 }

--- a/app/src/main/kotlin/com/realmsoffate/game/ui/panels/InventoryPage.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/ui/panels/InventoryPage.kt
@@ -27,6 +27,9 @@ private val EQUIPPABLE_TYPES = setOf("weapon", "armor", "shield", "amulet", "rin
 
 private fun signedAmt(n: Int): String = if (n >= 0) "+$n" else "$n"
 
+private fun String.titlecase(): String =
+    if (isEmpty()) this else this[0].uppercaseChar() + substring(1)
+
 // ----------------- INVENTORY (equipped slots + 5-col backpack grid) -----------------
 
 @Composable
@@ -226,7 +229,7 @@ private fun EquippedSlot(
                 Text(itemIconFor(item), style = MaterialTheme.typography.titleLarge)
                 Spacer(Modifier.width(8.dp))
                 Column {
-                    Text(item.name, style = MaterialTheme.typography.titleSmall, maxLines = 1)
+                    Text(item.name.titlecase(), style = MaterialTheme.typography.titleSmall, maxLines = 1)
                     if (item.ac != null) Text("AC ${item.ac}", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                     if (item.damage != null) Text(item.damage, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
@@ -236,7 +239,7 @@ private fun EquippedSlot(
                 Text(icon, style = MaterialTheme.typography.titleLarge, color = MaterialTheme.colorScheme.outline)
                 Spacer(Modifier.width(8.dp))
                 Text(
-                    "empty",
+                    "Empty",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -264,7 +267,7 @@ private fun SelectedItemCard(item: Item, onEquipToggle: () -> Unit, onUse: () ->
             }
             Spacer(Modifier.width(12.dp))
             Column(Modifier.weight(1f)) {
-                Text(item.name, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+                Text(item.name.titlecase(), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
                 Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
                     RarityTag(item.rarity, color)
                     TypeTag(item.type)
@@ -350,7 +353,7 @@ private fun BackpackCell(item: Item, selected: Boolean, onClick: () -> Unit) {
             Spacer(Modifier.width(8.dp))
             Column(Modifier.weight(1f)) {
                 Text(
-                    item.name,
+                    item.name.titlecase(),
                     style = MaterialTheme.typography.titleSmall,
                     maxLines = 1
                 )

--- a/app/src/main/kotlin/com/realmsoffate/game/ui/panels/InventoryPage.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/ui/panels/InventoryPage.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.realmsoffate.game.data.Item
+import com.realmsoffate.game.data.ItemEffect
 import com.realmsoffate.game.game.GameUiState
 import com.realmsoffate.game.ui.components.EmptyState
 import com.realmsoffate.game.ui.components.PanelSheet
@@ -23,6 +24,8 @@ import com.realmsoffate.game.ui.theme.RealmsSpacing
 import com.realmsoffate.game.ui.theme.RealmsTheme
 
 private val EQUIPPABLE_TYPES = setOf("weapon", "armor", "shield", "amulet", "ring", "clothes")
+
+private fun signedAmt(n: Int): String = if (n >= 0) "+$n" else "$n"
 
 // ----------------- INVENTORY (equipped slots + 5-col backpack grid) -----------------
 
@@ -279,6 +282,22 @@ private fun SelectedItemCard(item: Item, onEquipToggle: () -> Unit, onUse: () ->
         if (item.desc.isNotBlank()) {
             Spacer(Modifier.height(8.dp))
             Text(item.desc, style = MaterialTheme.typography.bodySmall)
+        }
+        if (item.effects.isNotEmpty()) {
+            Spacer(Modifier.height(6.dp))
+            item.effects.forEach { e ->
+                val line = when (e) {
+                    is ItemEffect.AbilityBonus -> "${signedAmt(e.amount)} ${e.stat.uppercase()}"
+                    is ItemEffect.SkillBonus   -> "${signedAmt(e.amount)} ${e.skill}"
+                    is ItemEffect.Resistance   -> "Resist ${e.damageType}"
+                    is ItemEffect.Immunity     -> "Immune ${e.damageType}"
+                    is ItemEffect.OnHit        -> "On hit: +${e.dice} ${e.damageType}"
+                    is ItemEffect.MaxHpBonus   -> "${signedAmt(e.amount)} max HP"
+                    is ItemEffect.PassiveTrigger -> e.text
+                }
+                Text(line, style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
         }
         Spacer(Modifier.height(10.dp))
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {

--- a/app/src/main/kotlin/com/realmsoffate/game/ui/panels/InventoryPage.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/ui/panels/InventoryPage.kt
@@ -206,7 +206,7 @@ private fun EquippedSlot(
         outlined = true,
         accentColor = rarityColor,
         contentPadding = RealmsSpacing.m,
-        modifier = modifier
+        modifier = modifier.heightIn(min = 88.dp)
     ) {
         Text(label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.primary)
         Spacer(Modifier.height(4.dp))

--- a/app/src/main/kotlin/com/realmsoffate/game/ui/panels/InventoryPage.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/ui/panels/InventoryPage.kt
@@ -22,16 +22,23 @@ import com.realmsoffate.game.ui.components.RealmsCard
 import com.realmsoffate.game.ui.theme.RealmsSpacing
 import com.realmsoffate.game.ui.theme.RealmsTheme
 
+private val EQUIPPABLE_TYPES = setOf("weapon", "armor", "shield", "amulet", "ring", "clothes")
+
 // ----------------- INVENTORY (equipped slots + 5-col backpack grid) -----------------
 
 @Composable
 internal fun InventoryContent(state: GameUiState, onEquip: (Item) -> Unit, onUse: (Item) -> Unit) {
     val ch = state.character ?: return
     var selected by remember(ch) { mutableStateOf<Item?>(null) }
-    // ---- Equipped slots (2 col) ----
+    // ---- Equipped slots ----
     val weapon = ch.inventory.firstOrNull { it.equipped && it.type == "weapon" }
     val armor = ch.inventory.firstOrNull { it.equipped && (it.type == "armor" || it.type == "shield") }
-    val equippedNames = listOfNotNull(weapon?.name, armor?.name)
+    val amulet = ch.inventory.firstOrNull { it.equipped && it.type == "amulet" }
+    val clothes = ch.inventory.firstOrNull { it.equipped && it.type == "clothes" }
+    val equippedRings = ch.inventory.filter { it.equipped && it.type == "ring" }.take(2)
+    val ring1 = equippedRings.getOrNull(0)
+    val ring2 = equippedRings.getOrNull(1)
+    val equippedNames = listOfNotNull(weapon?.name, armor?.name, amulet?.name, clothes?.name, ring1?.name, ring2?.name)
     val selectedIsEquipped = selected?.name in equippedNames
     InventorySectionHeader("EQUIPMENT")
     Row(
@@ -53,6 +60,46 @@ internal fun InventoryContent(state: GameUiState, onEquip: (Item) -> Unit, onUse
             modifier = Modifier.weight(1f)
         )
     }
+    Spacer(Modifier.height(8.dp))
+    Row(
+        Modifier.padding(horizontal = RealmsSpacing.l).fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        EquippedSlot(
+            label = "AMULET",
+            icon = "📿",
+            item = amulet,
+            onTap = { selected = amulet },
+            modifier = Modifier.weight(1f)
+        )
+        EquippedSlot(
+            label = "CLOTHES",
+            icon = "👕",
+            item = clothes,
+            onTap = { selected = clothes },
+            modifier = Modifier.weight(1f)
+        )
+    }
+    Spacer(Modifier.height(8.dp))
+    Row(
+        Modifier.padding(horizontal = RealmsSpacing.l).fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        EquippedSlot(
+            label = "RING 1",
+            icon = "💍",
+            item = ring1,
+            onTap = { selected = ring1 },
+            modifier = Modifier.weight(1f)
+        )
+        EquippedSlot(
+            label = "RING 2",
+            icon = "💍",
+            item = ring2,
+            onTap = { selected = ring2 },
+            modifier = Modifier.weight(1f)
+        )
+    }
     if (selectedIsEquipped) {
         Spacer(Modifier.height(8.dp))
         Box(Modifier.padding(horizontal = RealmsSpacing.l)) {
@@ -68,7 +115,7 @@ internal fun InventoryContent(state: GameUiState, onEquip: (Item) -> Unit, onUse
     }
     // ---- Backpack grid (2 col; detail card appears inline under the tapped row) ----
     InventorySectionHeader("BACKPACK")
-    val backpack = ch.inventory.filter { !(it.equipped && it.type in setOf("weapon", "armor", "shield")) }
+    val backpack = ch.inventory.filter { !(it.equipped && it.type in EQUIPPABLE_TYPES) }
     if (backpack.isEmpty()) {
         Text(
             "Pack is empty.",
@@ -220,7 +267,7 @@ private fun SelectedItemCard(item: Item, onEquipToggle: () -> Unit, onUse: () ->
         }
         Spacer(Modifier.height(10.dp))
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            if (item.type in setOf("weapon", "armor", "shield")) {
+            if (item.type in EQUIPPABLE_TYPES) {
                 Button(
                     onClick = onEquipToggle,
                     modifier = Modifier.weight(1f),
@@ -347,6 +394,9 @@ private fun itemEmoji(type: String): String = when (type.lowercase()) {
     "armor" -> "\uD83E\uDD7C"
     "shield" -> "\uD83D\uDEE1\uFE0F"
     "consumable" -> "\uD83E\uDDEA"
+    "amulet" -> "\uD83D\uDCFF"
+    "ring" -> "\uD83D\uDC8D"
+    "clothes" -> "\uD83D\uDC55"
     "scroll" -> "\uD83D\uDCDC"
     "key" -> "\uD83D\uDD11"
     "food" -> "\uD83C\uDF57"

--- a/app/src/main/kotlin/com/realmsoffate/game/ui/panels/InventoryPage.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/ui/panels/InventoryPage.kt
@@ -96,13 +96,6 @@ internal fun InventoryContent(state: GameUiState, onEquip: (Item) -> Unit, onUse
             onTap = { selected = amulet },
             modifier = Modifier.weight(1f)
         )
-        Spacer(Modifier.weight(1f))
-    }
-    Spacer(Modifier.height(8.dp))
-    Row(
-        Modifier.padding(horizontal = RealmsSpacing.l).fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
         EquippedSlot(
             label = "RING 1",
             icon = "💍",

--- a/app/src/main/kotlin/com/realmsoffate/game/ui/panels/InventoryPage.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/ui/panels/InventoryPage.kt
@@ -32,13 +32,14 @@ internal fun InventoryContent(state: GameUiState, onEquip: (Item) -> Unit, onUse
     var selected by remember(ch) { mutableStateOf<Item?>(null) }
     // ---- Equipped slots ----
     val weapon = ch.inventory.firstOrNull { it.equipped && it.type == "weapon" }
-    val armor = ch.inventory.firstOrNull { it.equipped && (it.type == "armor" || it.type == "shield") }
+    val armor = ch.inventory.firstOrNull { it.equipped && it.type == "armor" }
+    val shield = ch.inventory.firstOrNull { it.equipped && it.type == "shield" }
     val amulet = ch.inventory.firstOrNull { it.equipped && it.type == "amulet" }
     val clothes = ch.inventory.firstOrNull { it.equipped && it.type == "clothes" }
     val equippedRings = ch.inventory.filter { it.equipped && it.type == "ring" }.take(2)
     val ring1 = equippedRings.getOrNull(0)
     val ring2 = equippedRings.getOrNull(1)
-    val equippedNames = listOfNotNull(weapon?.name, armor?.name, amulet?.name, clothes?.name, ring1?.name, ring2?.name)
+    val equippedNames = listOfNotNull(weapon?.name, armor?.name, shield?.name, amulet?.name, clothes?.name, ring1?.name, ring2?.name)
     val selectedIsEquipped = selected?.name in equippedNames
     InventorySectionHeader("EQUIPMENT")
     Row(
@@ -53,10 +54,30 @@ internal fun InventoryContent(state: GameUiState, onEquip: (Item) -> Unit, onUse
             modifier = Modifier.weight(1f)
         )
         EquippedSlot(
-            label = "ARMOR",
+            label = "SHIELD",
             icon = "\uD83D\uDEE1\uFE0F",
+            item = shield,
+            onTap = { selected = shield },
+            modifier = Modifier.weight(1f)
+        )
+    }
+    Spacer(Modifier.height(8.dp))
+    Row(
+        Modifier.padding(horizontal = RealmsSpacing.l).fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        EquippedSlot(
+            label = "ARMOR",
+            icon = "🥼",
             item = armor,
             onTap = { selected = armor },
+            modifier = Modifier.weight(1f)
+        )
+        EquippedSlot(
+            label = "CLOTHES",
+            icon = "👕",
+            item = clothes,
+            onTap = { selected = clothes },
             modifier = Modifier.weight(1f)
         )
     }
@@ -72,13 +93,7 @@ internal fun InventoryContent(state: GameUiState, onEquip: (Item) -> Unit, onUse
             onTap = { selected = amulet },
             modifier = Modifier.weight(1f)
         )
-        EquippedSlot(
-            label = "CLOTHES",
-            icon = "👕",
-            item = clothes,
-            onTap = { selected = clothes },
-            modifier = Modifier.weight(1f)
-        )
+        Spacer(Modifier.weight(1f))
     }
     Spacer(Modifier.height(8.dp))
     Row(
@@ -297,7 +312,7 @@ private fun BackpackCell(item: Item, selected: Boolean, onClick: () -> Unit) {
         accentColor = color,
         selected = selected,
         contentPadding = RealmsSpacing.m,
-        modifier = Modifier.fillMaxWidth()
+        modifier = Modifier.fillMaxWidth().heightIn(min = 88.dp)
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Text(

--- a/app/src/main/kotlin/com/realmsoffate/game/ui/panels/InventoryPage.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/ui/panels/InventoryPage.kt
@@ -312,7 +312,7 @@ private fun BackpackCell(item: Item, selected: Boolean, onClick: () -> Unit) {
         accentColor = color,
         selected = selected,
         contentPadding = RealmsSpacing.m,
-        modifier = Modifier.fillMaxWidth().heightIn(min = 88.dp)
+        modifier = Modifier.fillMaxWidth().heightIn(min = 68.dp)
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Text(

--- a/app/src/main/kotlin/com/realmsoffate/game/ui/panels/InventoryPage.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/ui/panels/InventoryPage.kt
@@ -206,7 +206,7 @@ private fun EquippedSlot(
         outlined = true,
         accentColor = rarityColor,
         contentPadding = RealmsSpacing.m,
-        modifier = modifier.heightIn(min = 88.dp)
+        modifier = modifier.heightIn(min = 68.dp)
     ) {
         Text(label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.primary)
         Spacer(Modifier.height(4.dp))

--- a/app/src/test/kotlin/com/realmsoffate/game/data/AutoTagUnknownNpcsTest.kt
+++ b/app/src/test/kotlin/com/realmsoffate/game/data/AutoTagUnknownNpcsTest.kt
@@ -90,6 +90,40 @@ class AutoTagUnknownNpcsTest {
     }
 
     @Test
+    fun `skips equipment-like names ending in item category word`() {
+        val parsed = parsedWithSegments(
+            NarrationSegmentData.Prose("The Bone Shield deflects the blow. Iron Sword glints. Mira Cole watches.")
+        )
+        val specs = AutoTagUnknownNpcs.scan(
+            parsed = parsed,
+            existingNpcs = emptyList(),
+            currentLoc = "Hightower",
+            turn = 5
+        )
+        val names = specs.map { it.name }
+        assertTrue("Bone Shield should be filtered: $names", "Bone Shield" !in names)
+        assertTrue("Iron Sword should be filtered: $names", "Iron Sword" !in names)
+        assertTrue("Mira Cole should still be detected: $names", "Mira Cole" in names)
+    }
+
+    @Test
+    fun `skips names matching inventory items`() {
+        val parsed = parsedWithSegments(
+            NarrationSegmentData.Prose("Stormlight Brand hums in your hand. You see Elric Vance.")
+        )
+        val specs = AutoTagUnknownNpcs.scan(
+            parsed = parsed,
+            existingNpcs = emptyList(),
+            currentLoc = "Hightower",
+            turn = 5,
+            itemNames = setOf("Stormlight Brand")
+        )
+        val names = specs.map { it.name }
+        assertTrue("Stormlight Brand should be filtered as inventory: $names", "Stormlight Brand" !in names)
+        assertTrue("Elric Vance should be detected: $names", "Elric Vance" in names)
+    }
+
+    @Test
     fun `returns empty when all segments are blank`() {
         val parsed = parsedWithSegments(
             NarrationSegmentData.Prose("   "),

--- a/app/src/test/kotlin/com/realmsoffate/game/data/ItemEffectSerializationTest.kt
+++ b/app/src/test/kotlin/com/realmsoffate/game/data/ItemEffectSerializationTest.kt
@@ -1,0 +1,72 @@
+package com.realmsoffate.game.data
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ItemEffectSerializationTest {
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+    @Test fun abilityBonus_roundTrip() {
+        val e: ItemEffect = ItemEffect.AbilityBonus("STR", 2)
+        val s = json.encodeToString(ItemEffect.serializer(), e)
+        assertTrue("type tag present: $s", s.contains("\"type\":\"ability\""))
+        assertEquals(e, json.decodeFromString(ItemEffect.serializer(), s))
+    }
+
+    @Test fun skillBonus_roundTrip() {
+        val e: ItemEffect = ItemEffect.SkillBonus("Stealth", 2)
+        val s = json.encodeToString(ItemEffect.serializer(), e)
+        assertEquals(e, json.decodeFromString(ItemEffect.serializer(), s))
+    }
+
+    @Test fun resistance_roundTrip() {
+        val e: ItemEffect = ItemEffect.Resistance("fire")
+        assertEquals(e, json.decodeFromString(ItemEffect.serializer(),
+            json.encodeToString(ItemEffect.serializer(), e)))
+    }
+
+    @Test fun immunity_roundTrip() {
+        val e: ItemEffect = ItemEffect.Immunity("poison")
+        assertEquals(e, json.decodeFromString(ItemEffect.serializer(),
+            json.encodeToString(ItemEffect.serializer(), e)))
+    }
+
+    @Test fun onHit_roundTrip() {
+        val e: ItemEffect = ItemEffect.OnHit("1d4", "fire")
+        assertEquals(e, json.decodeFromString(ItemEffect.serializer(),
+            json.encodeToString(ItemEffect.serializer(), e)))
+    }
+
+    @Test fun maxHpBonus_roundTrip() {
+        val e: ItemEffect = ItemEffect.MaxHpBonus(5)
+        assertEquals(e, json.decodeFromString(ItemEffect.serializer(),
+            json.encodeToString(ItemEffect.serializer(), e)))
+    }
+
+    @Test fun passiveTrigger_roundTrip() {
+        val e: ItemEffect = ItemEffect.PassiveTrigger("cursed: -1 to all rolls")
+        assertEquals(e, json.decodeFromString(ItemEffect.serializer(),
+            json.encodeToString(ItemEffect.serializer(), e)))
+    }
+
+    @Test fun item_withoutEffectsField_decodes() {
+        val legacy = """{"name":"Rusty Sword","type":"weapon"}"""
+        val item = json.decodeFromString(Item.serializer(), legacy)
+        assertEquals("Rusty Sword", item.name)
+        assertTrue("legacy effects default empty", item.effects.isEmpty())
+    }
+
+    @Test fun item_withEffects_roundTrip() {
+        val item = Item(
+            name = "Flametongue",
+            type = "weapon",
+            damage = "1d8",
+            effects = listOf(ItemEffect.OnHit("1d6", "fire"), ItemEffect.AbilityBonus("CHA", 1))
+        )
+        val s = json.encodeToString(Item.serializer(), item)
+        val decoded = json.decodeFromString(Item.serializer(), s)
+        assertEquals(item, decoded)
+    }
+}

--- a/app/src/test/kotlin/com/realmsoffate/game/data/ItemSpecEffectsParseTest.kt
+++ b/app/src/test/kotlin/com/realmsoffate/game/data/ItemSpecEffectsParseTest.kt
@@ -1,0 +1,63 @@
+package com.realmsoffate.game.data
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ItemSpecEffectsParseTest {
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+    @Test fun itemSpec_parsesEffectsArray() {
+        val raw = """
+        {
+          "name": "Ring of Fire Resistance",
+          "desc": "Shimmers with heat.",
+          "type": "ring",
+          "rarity": "uncommon",
+          "effects": [
+            {"type":"resist","damageType":"fire"}
+          ]
+        }
+        """.trimIndent()
+        val spec = json.decodeFromString(ItemSpec.serializer(), raw)
+        assertEquals("Ring of Fire Resistance", spec.name)
+        assertEquals(1, spec.effects.size)
+        val e = spec.effects[0]
+        assertTrue(e is ItemEffect.Resistance)
+        assertEquals("fire", (e as ItemEffect.Resistance).damageType)
+    }
+
+    @Test fun itemSpec_absentEffects_defaultsEmpty() {
+        val raw = """{"name":"Apple","type":"consumable"}"""
+        val spec = json.decodeFromString(ItemSpec.serializer(), raw)
+        assertTrue(spec.effects.isEmpty())
+    }
+
+    @Test fun itemSpec_multipleEffects() {
+        val raw = """
+        {
+          "name": "Flametongue",
+          "type": "weapon",
+          "effects": [
+            {"type":"onhit","dice":"1d6","damageType":"fire"},
+            {"type":"ability","stat":"CHA","amount":1}
+          ]
+        }
+        """.trimIndent()
+        val spec = json.decodeFromString(ItemSpec.serializer(), raw)
+        assertEquals(2, spec.effects.size)
+    }
+
+    @Test fun itemSpecToItem_preservesEffects() {
+        val spec = ItemSpec(
+            name = "Ring of Fire Resistance",
+            type = "ring",
+            effects = listOf(ItemEffect.Resistance("fire"))
+        )
+        val item = Item(name = spec.name, desc = spec.desc, type = spec.type,
+            rarity = spec.rarity, effects = spec.effects)
+        assertEquals(1, item.effects.size)
+        assertTrue(item.effects[0] is ItemEffect.Resistance)
+    }
+}

--- a/app/src/test/kotlin/com/realmsoffate/game/game/EquipToggleEffectsTest.kt
+++ b/app/src/test/kotlin/com/realmsoffate/game/game/EquipToggleEffectsTest.kt
@@ -1,0 +1,71 @@
+package com.realmsoffate.game.game
+
+import com.realmsoffate.game.data.Abilities
+import com.realmsoffate.game.data.Character
+import com.realmsoffate.game.data.Item
+import com.realmsoffate.game.data.ItemEffect
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class EquipToggleEffectsTest {
+
+    private fun baseCharacter(vararg items: Item): Character =
+        Character(name = "T", race = "Human", cls = "Fighter",
+            abilities = Abilities(dex = 14), maxHp = 20, hp = 20, ac = 12,
+            inventory = items.toMutableList())
+
+    @Test fun equippingAmulet_raisesMaxHp_doesNotHealCurrent() {
+        val amulet = Item("Amulet of Health", type = "amulet", equipped = false,
+            effects = listOf(ItemEffect.MaxHpBonus(5)))
+        val ch = baseCharacter(amulet).copy(hp = 18)
+        val (maxHp, hp) = EquipmentEffects.recalcHpAfterEquip(
+            oldChar = ch,
+            newChar = ch.copy(inventory = mutableListOf(amulet.copy(equipped = true)))
+        )
+        assertEquals(25, maxHp)
+        assertEquals(18, hp)
+    }
+
+    @Test fun unequippingAmulet_dropsMaxHp_clampsHp() {
+        val amulet = Item("Amulet of Health", type = "amulet", equipped = true,
+            effects = listOf(ItemEffect.MaxHpBonus(5)))
+        val ch = baseCharacter(amulet).copy(maxHp = 25, hp = 25)
+        val (maxHp, hp) = EquipmentEffects.recalcHpAfterEquip(
+            oldChar = ch,
+            newChar = ch.copy(inventory = mutableListOf(amulet.copy(equipped = false)))
+        )
+        assertEquals(20, maxHp)
+        assertEquals(20, hp)
+    }
+
+    @Test fun unequippingAmulet_whenAlreadyWounded_keepsWoundedHp() {
+        val amulet = Item("Amulet of Health", type = "amulet", equipped = true,
+            effects = listOf(ItemEffect.MaxHpBonus(5)))
+        val ch = baseCharacter(amulet).copy(maxHp = 25, hp = 12)
+        val (maxHp, hp) = EquipmentEffects.recalcHpAfterEquip(
+            oldChar = ch,
+            newChar = ch.copy(inventory = mutableListOf(amulet.copy(equipped = false)))
+        )
+        assertEquals(20, maxHp)
+        assertEquals(12, hp)
+    }
+
+    @Test fun equipSwap_betweenArmorPieces_changesAcLive() {
+        val leather = Item("Leather Armor", type = "armor", ac = 11, equipped = true)
+        val plate = Item("Plate Armor", type = "armor", ac = 18, equipped = false)
+        val ch = baseCharacter(leather, plate).copy(ac = 13)
+        val newCh = ch.copy(inventory = mutableListOf(
+            leather.copy(equipped = false),
+            plate.copy(equipped = true)
+        ))
+        assertEquals(18, EquipmentEffects.effectiveAc(newCh))
+    }
+
+    @Test fun abilityBonus_reflectedInEffectiveAbilities_notBase() {
+        val ring = Item("Ring of Strength", type = "ring", equipped = true,
+            effects = listOf(ItemEffect.AbilityBonus("STR", 2)))
+        val ch = baseCharacter(ring).copy(abilities = Abilities(str = 14))
+        assertEquals(14, ch.abilities.str)
+        assertEquals(16, EquipmentEffects.effectiveAbilities(ch).str)
+    }
+}

--- a/app/src/test/kotlin/com/realmsoffate/game/game/EquipmentEffectsTest.kt
+++ b/app/src/test/kotlin/com/realmsoffate/game/game/EquipmentEffectsTest.kt
@@ -153,6 +153,15 @@ class EquipmentEffectsTest {
         assertEquals("thunder", riders[2].damageType)
     }
 
+    @Test fun applyClassStart_setsAcViaEffectiveAc() {
+        val ch = Character(name = "T", race = "Human", cls = "Fighter",
+            abilities = Abilities(dex = 14, con = 12))
+        val cls = Classes.find("Fighter")!!
+        applyClassStart(ch, cls)
+        // Fighter starts with Chain Mail (heavy, AC 16, ignores DEX) + Shield (+2) = 18.
+        assertEquals(18, ch.ac)
+    }
+
     @Test fun passiveTriggers_returnsText() {
         val cursed = Item("Cursed Ring", equipped = true,
             effects = listOf(ItemEffect.PassiveTrigger("cursed: -1 to all rolls")))

--- a/app/src/test/kotlin/com/realmsoffate/game/game/EquipmentEffectsTest.kt
+++ b/app/src/test/kotlin/com/realmsoffate/game/game/EquipmentEffectsTest.kt
@@ -98,4 +98,70 @@ class EquipmentEffectsTest {
         val ch = char(cloak, abilities = Abilities(dex = 14))
         assertEquals(13, EquipmentEffects.effectiveAc(ch))
     }
+
+    @Test fun effectiveMaxHp_addsMaxHpBonuses() {
+        val amulet = Item("Amulet of Health", equipped = true,
+            effects = listOf(ItemEffect.MaxHpBonus(5)))
+        val ch = char(amulet).copy(maxHp = 20)
+        assertEquals(25, EquipmentEffects.effectiveMaxHp(ch))
+    }
+
+    @Test fun effectiveMaxHp_ignoresUnequipped() {
+        val amulet = Item("Amulet of Health", equipped = false,
+            effects = listOf(ItemEffect.MaxHpBonus(5)))
+        val ch = char(amulet).copy(maxHp = 20)
+        assertEquals(20, EquipmentEffects.effectiveMaxHp(ch))
+    }
+
+    @Test fun skillBonuses_sumsByCanonicalKey() {
+        val boots = Item("Boots of Stealth", equipped = true,
+            effects = listOf(ItemEffect.SkillBonus("Stealth", 2)))
+        val cloak = Item("Shadow Cloak", equipped = true,
+            effects = listOf(ItemEffect.SkillBonus("stealth", 1), ItemEffect.SkillBonus("Perception", 1)))
+        val ch = char(boots, cloak)
+        val b = EquipmentEffects.skillBonuses(ch)
+        assertEquals(3, b["Stealth"])
+        assertEquals(1, b["Perception"])
+    }
+
+    @Test fun resistances_setOfLowercaseDamageTypes() {
+        val ring1 = Item("R1", equipped = true, effects = listOf(ItemEffect.Resistance("Fire")))
+        val ring2 = Item("R2", equipped = true,
+            effects = listOf(ItemEffect.Resistance("fire"), ItemEffect.Resistance("cold")))
+        val ch = char(ring1, ring2)
+        assertEquals(setOf("fire", "cold"), EquipmentEffects.resistances(ch))
+    }
+
+    @Test fun immunities_onlyFromImmunityEffects() {
+        val ring = Item("R", equipped = true,
+            effects = listOf(ItemEffect.Immunity("poison"), ItemEffect.Resistance("fire")))
+        val ch = char(ring)
+        assertEquals(setOf("poison"), EquipmentEffects.immunities(ch))
+        assertEquals(setOf("fire"), EquipmentEffects.resistances(ch))
+    }
+
+    @Test fun onHitRiders_orderPreserved() {
+        val sword = Item("Flametongue", equipped = true,
+            effects = listOf(ItemEffect.OnHit("1d6", "fire"), ItemEffect.OnHit("1d4", "radiant")))
+        val ring = Item("Thunder Ring", equipped = true,
+            effects = listOf(ItemEffect.OnHit("1d4", "thunder")))
+        val ch = char(sword, ring)
+        val riders = EquipmentEffects.onHitRiders(ch)
+        assertEquals(3, riders.size)
+        assertEquals("fire", riders[0].damageType)
+        assertEquals("radiant", riders[1].damageType)
+        assertEquals("thunder", riders[2].damageType)
+    }
+
+    @Test fun passiveTriggers_returnsText() {
+        val cursed = Item("Cursed Ring", equipped = true,
+            effects = listOf(ItemEffect.PassiveTrigger("cursed: -1 to all rolls")))
+        val vorpal = Item("Vorpal Sword", equipped = true,
+            effects = listOf(ItemEffect.PassiveTrigger("vorpal: on nat 20, narrate decapitation")))
+        val ch = char(cursed, vorpal)
+        val texts = EquipmentEffects.passiveTriggers(ch)
+        assertEquals(2, texts.size)
+        assertTrue(texts.any { it.startsWith("cursed") })
+        assertTrue(texts.any { it.startsWith("vorpal") })
+    }
 }

--- a/app/src/test/kotlin/com/realmsoffate/game/game/EquipmentEffectsTest.kt
+++ b/app/src/test/kotlin/com/realmsoffate/game/game/EquipmentEffectsTest.kt
@@ -55,4 +55,47 @@ class EquipmentEffectsTest {
         val ch = char(Item("X", effects = listOf(ItemEffect.Resistance("fire"))))
         assertTrue(EquipmentEffects.activeEffects(ch).isEmpty())
     }
+
+    @Test fun effectiveAc_unarmoredEquals10PlusDex() {
+        val ch = char(abilities = Abilities(dex = 14))
+        assertEquals(12, EquipmentEffects.effectiveAc(ch))
+    }
+
+    @Test fun effectiveAc_lightArmorAddsDex() {
+        val leather = Item("Leather Armor", type = "armor", ac = 11, equipped = true)
+        val ch = char(leather, abilities = Abilities(dex = 14))
+        assertEquals(13, EquipmentEffects.effectiveAc(ch))
+    }
+
+    @Test fun effectiveAc_heavyArmorIgnoresDex() {
+        val plate = Item("Plate Armor", type = "armor", ac = 18, equipped = true)
+        val ch = char(plate, abilities = Abilities(dex = 16))
+        assertEquals(18, EquipmentEffects.effectiveAc(ch))
+    }
+
+    @Test fun effectiveAc_chainMailIgnoresDex() {
+        val chain = Item("Chain Mail", type = "armor", ac = 16, equipped = true)
+        val ch = char(chain, abilities = Abilities(dex = 16))
+        assertEquals(16, EquipmentEffects.effectiveAc(ch))
+    }
+
+    @Test fun effectiveAc_shieldAddsTwo() {
+        val leather = Item("Leather Armor", type = "armor", ac = 11, equipped = true)
+        val shield = Item("Shield", type = "shield", equipped = true)
+        val ch = char(leather, shield, abilities = Abilities(dex = 14))
+        assertEquals(15, EquipmentEffects.effectiveAc(ch))
+    }
+
+    @Test fun effectiveAc_unequippedArmorIgnored() {
+        val leather = Item("Leather Armor", type = "armor", ac = 11, equipped = false)
+        val ch = char(leather, abilities = Abilities(dex = 14))
+        assertEquals(12, EquipmentEffects.effectiveAc(ch))
+    }
+
+    @Test fun effectiveAc_usesEffectiveDex() {
+        val cloak = Item("Cloak of Dex", type = "clothes", equipped = true,
+            effects = listOf(ItemEffect.AbilityBonus("DEX", 2)))
+        val ch = char(cloak, abilities = Abilities(dex = 14))
+        assertEquals(13, EquipmentEffects.effectiveAc(ch))
+    }
 }

--- a/app/src/test/kotlin/com/realmsoffate/game/game/EquipmentEffectsTest.kt
+++ b/app/src/test/kotlin/com/realmsoffate/game/game/EquipmentEffectsTest.kt
@@ -1,0 +1,58 @@
+package com.realmsoffate.game.game
+
+import com.realmsoffate.game.data.Abilities
+import com.realmsoffate.game.data.Character
+import com.realmsoffate.game.data.Item
+import com.realmsoffate.game.data.ItemEffect
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EquipmentEffectsTest {
+
+    private fun char(vararg items: Item, abilities: Abilities = Abilities()): Character =
+        Character(name = "T", race = "Human", cls = "Fighter", abilities = abilities,
+            inventory = items.toMutableList())
+
+    @Test fun activeEffects_onlyEquipped() {
+        val equipped = Item("A", equipped = true,
+            effects = listOf(ItemEffect.AbilityBonus("STR", 2)))
+        val unequipped = Item("B", equipped = false,
+            effects = listOf(ItemEffect.AbilityBonus("STR", 99)))
+        val ch = char(equipped, unequipped)
+        val active = EquipmentEffects.activeEffects(ch)
+        assertEquals(1, active.size)
+        assertEquals(ItemEffect.AbilityBonus("STR", 2), active[0])
+    }
+
+    @Test fun effectiveAbilities_sumsAllEquippedAbilityBonuses() {
+        val ring1 = Item("R1", type = "ring", equipped = true,
+            effects = listOf(ItemEffect.AbilityBonus("STR", 2)))
+        val ring2 = Item("R2", type = "ring", equipped = true,
+            effects = listOf(ItemEffect.AbilityBonus("STR", 1), ItemEffect.AbilityBonus("DEX", 1)))
+        val ch = char(ring1, ring2, abilities = Abilities(str = 10, dex = 12))
+        val eff = EquipmentEffects.effectiveAbilities(ch)
+        assertEquals(13, eff.str)
+        assertEquals(13, eff.dex)
+        assertEquals(10, ch.abilities.str)
+    }
+
+    @Test fun effectiveAbilities_ignoresUnequipped() {
+        val ring = Item("R", type = "ring", equipped = false,
+            effects = listOf(ItemEffect.AbilityBonus("CON", 4)))
+        val ch = char(ring, abilities = Abilities(con = 12))
+        assertEquals(12, EquipmentEffects.effectiveAbilities(ch).con)
+    }
+
+    @Test fun effectiveAbilities_caseInsensitiveStat() {
+        val ring = Item("R", type = "ring", equipped = true,
+            effects = listOf(ItemEffect.AbilityBonus("str", 3)))
+        val ch = char(ring, abilities = Abilities(str = 10))
+        assertEquals(13, EquipmentEffects.effectiveAbilities(ch).str)
+    }
+
+    @Test fun activeEffects_emptyWhenNothingEquipped() {
+        val ch = char(Item("X", effects = listOf(ItemEffect.Resistance("fire"))))
+        assertTrue(EquipmentEffects.activeEffects(ch).isEmpty())
+    }
+}

--- a/app/src/test/kotlin/com/realmsoffate/game/game/PromptSummaryTest.kt
+++ b/app/src/test/kotlin/com/realmsoffate/game/game/PromptSummaryTest.kt
@@ -1,0 +1,53 @@
+package com.realmsoffate.game.game
+
+import com.realmsoffate.game.data.Abilities
+import com.realmsoffate.game.data.Character
+import com.realmsoffate.game.data.Item
+import com.realmsoffate.game.data.ItemEffect
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PromptSummaryTest {
+
+    private fun char(vararg items: Item): Character =
+        Character(name = "T", race = "Human", cls = "Fighter",
+            abilities = Abilities(), inventory = items.toMutableList())
+
+    @Test fun empty_whenNoEquippedWithEffects() {
+        val ch = char(Item("Apple", type = "consumable"))
+        assertEquals("", EquipmentEffects.promptSummary(ch))
+    }
+
+    @Test fun rendersWeaponsArmorAbilitySkillResistOnHitTrigger() {
+        val sword = Item("Flametongue", type = "weapon", damage = "1d8", equipped = true,
+            effects = listOf(ItemEffect.OnHit("1d6", "fire")))
+        val plate = Item("Plate Armor", type = "armor", ac = 18, equipped = true)
+        val ringStr = Item("Ring of Strength", type = "ring", equipped = true,
+            effects = listOf(ItemEffect.AbilityBonus("STR", 2)))
+        val cloak = Item("Cloak of Stealth", type = "clothes", equipped = true,
+            effects = listOf(ItemEffect.SkillBonus("Stealth", 2)))
+        val ringFire = Item("Fire Resist Ring", type = "ring", equipped = true,
+            effects = listOf(ItemEffect.Resistance("fire")))
+        val amulet = Item("Amulet of Antivenom", type = "amulet", equipped = true,
+            effects = listOf(ItemEffect.Immunity("poison")))
+        val cursed = Item("Cursed Ring", type = "ring", equipped = true,
+            effects = listOf(ItemEffect.PassiveTrigger("cursed: -1 to all rolls")))
+        val ch = char(sword, plate, ringStr, cloak, ringFire, amulet, cursed)
+        val out = EquipmentEffects.promptSummary(ch)
+        assertTrue("heading present", out.startsWith("Equipped gear:"))
+        assertTrue("weapon line", out.contains("Flametongue") && out.contains("1d8"))
+        assertTrue("on-hit", out.contains("on hit: +1d6 fire"))
+        assertTrue("armor line", out.contains("Plate Armor") && out.contains("AC 18"))
+        assertTrue("ability bonus marked applied", out.contains("+2 STR") && out.contains("applied"))
+        assertTrue("skill bonus", out.contains("+2 Stealth"))
+        assertTrue("resistances line", out.contains("Resistances: fire"))
+        assertTrue("immunities line", out.contains("Immunities: poison"))
+        assertTrue("passive trigger", out.contains("cursed: -1 to all rolls"))
+    }
+
+    @Test fun skipsItemsWithNoEffectsAndNoStatFields() {
+        val trinket = Item("Lucky Coin", type = "item", equipped = true)
+        assertEquals("", EquipmentEffects.promptSummary(char(trinket)))
+    }
+}

--- a/docs/superpowers/plans/2026-04-24-equipment-effects.md
+++ b/docs/superpowers/plans/2026-04-24-equipment-effects.md
@@ -1,0 +1,1303 @@
+# Equipment Effects Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make equipped items alter game state and LLM reasoning — code owns AC/maxHP/ability-score math (live-recomputed on equip/unequip), and the LLM prompt carries a structured summary of every equipped effect (skills, resistances, on-hit, passive triggers) so it respects them in checks and combat narration.
+
+**Architecture:** Introduce a polymorphic `ItemEffect` sealed interface attached to `Item` and `ItemSpec`. A new pure-Kotlin `EquipmentEffects` helper computes effective stats and produces a human-readable prompt block. `equipToggle` writes through AC/maxHP deltas and clamps HP. Ability math everywhere reads `effectiveAbilities(ch)` instead of `ch.abilities`. LLM loot schema gains an `effects` array. Each effect type has a dedicated test.
+
+**Tech Stack:** Kotlin, kotlinx.serialization (polymorphic sealed-class serialization), JUnit 4 (JVM tests under `app/src/test/kotlin/`), Jetpack Compose for the UI surfaces.
+
+**Spec:** `docs/superpowers/specs/2026-04-24-equipment-effects-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+- `app/src/main/kotlin/com/realmsoffate/game/game/EquipmentEffects.kt` — pure helper functions for effective stats, prompt summary, resistance/immunity/on-hit aggregation.
+- `app/src/test/kotlin/com/realmsoffate/game/data/ItemEffectSerializationTest.kt` — polymorphic JSON round-trip per sealed subtype.
+- `app/src/test/kotlin/com/realmsoffate/game/data/ItemSpecEffectsParseTest.kt` — LLM loot JSON → Item inventory transfer with effects preserved.
+- `app/src/test/kotlin/com/realmsoffate/game/game/EquipmentEffectsTest.kt` — each public `EquipmentEffects` function, per effect type.
+- `app/src/test/kotlin/com/realmsoffate/game/game/EquipToggleEffectsTest.kt` — VM-level equip/unequip recomputation (JVM, no Android deps — directly exercise the relevant pure logic).
+- `app/src/test/kotlin/com/realmsoffate/game/game/PromptSummaryTest.kt` — snapshot the prompt block string.
+
+**Modified files:**
+- `app/src/main/kotlin/com/realmsoffate/game/data/Models.kt` — add `ItemEffect` sealed interface; add `effects: List<ItemEffect> = emptyList()` to `Item` and `ItemSpec`.
+- `app/src/main/kotlin/com/realmsoffate/game/game/Classes.kt` — replace hand-rolled AC calc at lines 199-201 with `EquipmentEffects.effectiveAc(ch)`.
+- `app/src/main/kotlin/com/realmsoffate/game/game/GameViewModel.kt` — update:
+  - L423: print effective abilities in `/describe` output.
+  - L427, L1180: emit `EquipmentEffects.promptSummary(ch)` for equipped-gear section of LLM prompt.
+  - L833, L857, L913: read `EquipmentEffects.effectiveAbilities(ch).modByName(ability)` for skill/ability check math.
+  - L1645-1675: `equipToggle` recomputes AC + maxHp delta + HP clamp on every toggle, and carries through items_gained effects.
+  - Wherever `items_gained: List<ItemSpec>` is materialized into inventory (find with grep), copy `spec.effects` onto the new `Item`.
+- `app/src/main/kotlin/com/realmsoffate/game/data/Prompts.kt` — extend the `items_gained` JSON schema at L221 to include `effects`; add a short narrator instruction explaining how to use equipped-gear effects in checks and combat.
+- `app/src/main/kotlin/com/realmsoffate/game/ui/panels/InventoryPage.kt` — render effect chips on `SelectedItemCard` and mark backpack cells with an effect indicator.
+
+---
+
+## Task 1: Add `ItemEffect` sealed interface + `effects` field
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/realmsoffate/game/data/Models.kt`
+- Test: `app/src/test/kotlin/com/realmsoffate/game/data/ItemEffectSerializationTest.kt`
+
+- [ ] **Step 1: Write failing test**
+
+Create `app/src/test/kotlin/com/realmsoffate/game/data/ItemEffectSerializationTest.kt`:
+
+```kotlin
+package com.realmsoffate.game.data
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ItemEffectSerializationTest {
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+    @Test fun abilityBonus_roundTrip() {
+        val e: ItemEffect = ItemEffect.AbilityBonus("STR", 2)
+        val s = json.encodeToString(ItemEffect.serializer(), e)
+        assertTrue("type tag present: $s", s.contains("\"type\":\"ability\""))
+        assertEquals(e, json.decodeFromString(ItemEffect.serializer(), s))
+    }
+
+    @Test fun skillBonus_roundTrip() {
+        val e: ItemEffect = ItemEffect.SkillBonus("Stealth", 2)
+        val s = json.encodeToString(ItemEffect.serializer(), e)
+        assertEquals(e, json.decodeFromString(ItemEffect.serializer(), s))
+    }
+
+    @Test fun resistance_roundTrip() {
+        val e: ItemEffect = ItemEffect.Resistance("fire")
+        assertEquals(e, json.decodeFromString(ItemEffect.serializer(),
+            json.encodeToString(ItemEffect.serializer(), e)))
+    }
+
+    @Test fun immunity_roundTrip() {
+        val e: ItemEffect = ItemEffect.Immunity("poison")
+        assertEquals(e, json.decodeFromString(ItemEffect.serializer(),
+            json.encodeToString(ItemEffect.serializer(), e)))
+    }
+
+    @Test fun onHit_roundTrip() {
+        val e: ItemEffect = ItemEffect.OnHit("1d4", "fire")
+        assertEquals(e, json.decodeFromString(ItemEffect.serializer(),
+            json.encodeToString(ItemEffect.serializer(), e)))
+    }
+
+    @Test fun maxHpBonus_roundTrip() {
+        val e: ItemEffect = ItemEffect.MaxHpBonus(5)
+        assertEquals(e, json.decodeFromString(ItemEffect.serializer(),
+            json.encodeToString(ItemEffect.serializer(), e)))
+    }
+
+    @Test fun passiveTrigger_roundTrip() {
+        val e: ItemEffect = ItemEffect.PassiveTrigger("cursed: -1 to all rolls")
+        assertEquals(e, json.decodeFromString(ItemEffect.serializer(),
+            json.encodeToString(ItemEffect.serializer(), e)))
+    }
+
+    @Test fun item_withoutEffectsField_decodes() {
+        // Legacy save — no `effects` key present at all.
+        val legacy = """{"name":"Rusty Sword","type":"weapon"}"""
+        val item = json.decodeFromString(Item.serializer(), legacy)
+        assertEquals("Rusty Sword", item.name)
+        assertTrue("legacy effects default empty", item.effects.isEmpty())
+    }
+
+    @Test fun item_withEffects_roundTrip() {
+        val item = Item(
+            name = "Flametongue",
+            type = "weapon",
+            damage = "1d8",
+            effects = listOf(ItemEffect.OnHit("1d6", "fire"), ItemEffect.AbilityBonus("CHA", 1))
+        )
+        val s = json.encodeToString(Item.serializer(), item)
+        val decoded = json.decodeFromString(Item.serializer(), s)
+        assertEquals(item, decoded)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `gradle :app:testDebugUnitTest --tests "com.realmsoffate.game.data.ItemEffectSerializationTest"`
+Expected: FAIL — `ItemEffect` unresolved reference; `Item.effects` unresolved.
+
+- [ ] **Step 3: Add sealed interface + effects fields**
+
+Append to `app/src/main/kotlin/com/realmsoffate/game/data/Models.kt` (just below the `Item` data class at line 27-36):
+
+```kotlin
+@Serializable
+sealed interface ItemEffect {
+    @Serializable @SerialName("ability") data class AbilityBonus(val stat: String, val amount: Int) : ItemEffect
+    @Serializable @SerialName("skill")   data class SkillBonus(val skill: String, val amount: Int) : ItemEffect
+    @Serializable @SerialName("resist")  data class Resistance(val damageType: String) : ItemEffect
+    @Serializable @SerialName("immune")  data class Immunity(val damageType: String) : ItemEffect
+    @Serializable @SerialName("onhit")   data class OnHit(val dice: String, val damageType: String) : ItemEffect
+    @Serializable @SerialName("maxhp")   data class MaxHpBonus(val amount: Int) : ItemEffect
+    @Serializable @SerialName("trigger") data class PassiveTrigger(val text: String) : ItemEffect
+}
+```
+
+Add `effects` to `Item` (line 27-36):
+
+```kotlin
+@Serializable
+data class Item(
+    val name: String,
+    val desc: String = "",
+    val type: String = "item",
+    val rarity: String = "common",
+    var qty: Int = 1,
+    var equipped: Boolean = false,
+    val damage: String? = null,
+    val ac: Int? = null,
+    val effects: List<ItemEffect> = emptyList()
+)
+```
+
+Add `effects` to `ItemSpec` (around line 471):
+
+```kotlin
+@Serializable
+data class ItemSpec(
+    val name: String = "",
+    val desc: String = "",
+    val type: String = "item",
+    val rarity: String = "common",
+    val effects: List<ItemEffect> = emptyList()
+)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `gradle :app:testDebugUnitTest --tests "com.realmsoffate.game.data.ItemEffectSerializationTest"`
+Expected: PASS (8 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/kotlin/com/realmsoffate/game/data/Models.kt \
+        app/src/test/kotlin/com/realmsoffate/game/data/ItemEffectSerializationTest.kt
+git commit -m "feat(equipment): ItemEffect sealed interface + effects field on Item/ItemSpec"
+```
+
+---
+
+## Task 2: `EquipmentEffects.activeEffects` + `effectiveAbilities`
+
+**Files:**
+- Create: `app/src/main/kotlin/com/realmsoffate/game/game/EquipmentEffects.kt`
+- Test: `app/src/test/kotlin/com/realmsoffate/game/game/EquipmentEffectsTest.kt`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `app/src/test/kotlin/com/realmsoffate/game/game/EquipmentEffectsTest.kt`:
+
+```kotlin
+package com.realmsoffate.game.game
+
+import com.realmsoffate.game.data.Abilities
+import com.realmsoffate.game.data.Character
+import com.realmsoffate.game.data.Item
+import com.realmsoffate.game.data.ItemEffect
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EquipmentEffectsTest {
+
+    private fun char(vararg items: Item, abilities: Abilities = Abilities()): Character =
+        Character(name = "T", race = "Human", cls = "Fighter", abilities = abilities,
+            inventory = items.toMutableList())
+
+    @Test fun activeEffects_onlyEquipped() {
+        val equipped = Item("A", equipped = true,
+            effects = listOf(ItemEffect.AbilityBonus("STR", 2)))
+        val unequipped = Item("B", equipped = false,
+            effects = listOf(ItemEffect.AbilityBonus("STR", 99)))
+        val ch = char(equipped, unequipped)
+        val active = EquipmentEffects.activeEffects(ch)
+        assertEquals(1, active.size)
+        assertEquals(ItemEffect.AbilityBonus("STR", 2), active[0])
+    }
+
+    @Test fun effectiveAbilities_sumsAllEquippedAbilityBonuses() {
+        val ring1 = Item("R1", type = "ring", equipped = true,
+            effects = listOf(ItemEffect.AbilityBonus("STR", 2)))
+        val ring2 = Item("R2", type = "ring", equipped = true,
+            effects = listOf(ItemEffect.AbilityBonus("STR", 1), ItemEffect.AbilityBonus("DEX", 1)))
+        val ch = char(ring1, ring2, abilities = Abilities(str = 10, dex = 12))
+        val eff = EquipmentEffects.effectiveAbilities(ch)
+        assertEquals(13, eff.str)
+        assertEquals(13, eff.dex)
+        // Originals untouched
+        assertEquals(10, ch.abilities.str)
+    }
+
+    @Test fun effectiveAbilities_ignoresUnequipped() {
+        val ring = Item("R", type = "ring", equipped = false,
+            effects = listOf(ItemEffect.AbilityBonus("CON", 4)))
+        val ch = char(ring, abilities = Abilities(con = 12))
+        assertEquals(12, EquipmentEffects.effectiveAbilities(ch).con)
+    }
+
+    @Test fun effectiveAbilities_caseInsensitiveStat() {
+        val ring = Item("R", type = "ring", equipped = true,
+            effects = listOf(ItemEffect.AbilityBonus("str", 3)))
+        val ch = char(ring, abilities = Abilities(str = 10))
+        assertEquals(13, EquipmentEffects.effectiveAbilities(ch).str)
+    }
+
+    @Test fun activeEffects_emptyWhenNothingEquipped() {
+        val ch = char(Item("X", effects = listOf(ItemEffect.Resistance("fire"))))
+        assertTrue(EquipmentEffects.activeEffects(ch).isEmpty())
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `gradle :app:testDebugUnitTest --tests "com.realmsoffate.game.game.EquipmentEffectsTest"`
+Expected: FAIL — `EquipmentEffects` unresolved.
+
+- [ ] **Step 3: Create `EquipmentEffects.kt` with the two functions**
+
+Create `app/src/main/kotlin/com/realmsoffate/game/game/EquipmentEffects.kt`:
+
+```kotlin
+package com.realmsoffate.game.game
+
+import com.realmsoffate.game.data.Abilities
+import com.realmsoffate.game.data.Character
+import com.realmsoffate.game.data.ItemEffect
+
+object EquipmentEffects {
+
+    fun activeEffects(ch: Character): List<ItemEffect> =
+        ch.inventory.filter { it.equipped }.flatMap { it.effects }
+
+    fun effectiveAbilities(ch: Character): Abilities {
+        var str = ch.abilities.str
+        var dex = ch.abilities.dex
+        var con = ch.abilities.con
+        var int = ch.abilities.int
+        var wis = ch.abilities.wis
+        var cha = ch.abilities.cha
+        activeEffects(ch).forEach { e ->
+            if (e is ItemEffect.AbilityBonus) {
+                when (e.stat.uppercase()) {
+                    "STR" -> str += e.amount
+                    "DEX" -> dex += e.amount
+                    "CON" -> con += e.amount
+                    "INT" -> int += e.amount
+                    "WIS" -> wis += e.amount
+                    "CHA" -> cha += e.amount
+                }
+            }
+        }
+        return Abilities(str, dex, con, int, wis, cha)
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `gradle :app:testDebugUnitTest --tests "com.realmsoffate.game.game.EquipmentEffectsTest"`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/kotlin/com/realmsoffate/game/game/EquipmentEffects.kt \
+        app/src/test/kotlin/com/realmsoffate/game/game/EquipmentEffectsTest.kt
+git commit -m "feat(equipment): EquipmentEffects.activeEffects + effectiveAbilities"
+```
+
+---
+
+## Task 3: `effectiveAc`
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/realmsoffate/game/game/EquipmentEffects.kt`
+- Test: `app/src/test/kotlin/com/realmsoffate/game/game/EquipmentEffectsTest.kt`
+
+- [ ] **Step 1: Append failing tests to `EquipmentEffectsTest.kt`**
+
+```kotlin
+    @Test fun effectiveAc_unarmoredEquals10PlusDex() {
+        val ch = char(abilities = Abilities(dex = 14))
+        assertEquals(12, EquipmentEffects.effectiveAc(ch))
+    }
+
+    @Test fun effectiveAc_lightArmorAddsDex() {
+        val leather = Item("Leather Armor", type = "armor", ac = 11, equipped = true)
+        val ch = char(leather, abilities = Abilities(dex = 14))
+        assertEquals(13, EquipmentEffects.effectiveAc(ch))
+    }
+
+    @Test fun effectiveAc_heavyArmorIgnoresDex() {
+        val plate = Item("Plate Armor", type = "armor", ac = 18, equipped = true)
+        val ch = char(plate, abilities = Abilities(dex = 16))
+        assertEquals(18, EquipmentEffects.effectiveAc(ch))
+    }
+
+    @Test fun effectiveAc_chainMailIgnoresDex() {
+        val chain = Item("Chain Mail", type = "armor", ac = 16, equipped = true)
+        val ch = char(chain, abilities = Abilities(dex = 16))
+        assertEquals(16, EquipmentEffects.effectiveAc(ch))
+    }
+
+    @Test fun effectiveAc_shieldAddsTwo() {
+        val leather = Item("Leather Armor", type = "armor", ac = 11, equipped = true)
+        val shield = Item("Shield", type = "shield", equipped = true)
+        val ch = char(leather, shield, abilities = Abilities(dex = 14))
+        assertEquals(15, EquipmentEffects.effectiveAc(ch)) // 11 + 2 dex + 2 shield
+    }
+
+    @Test fun effectiveAc_unequippedArmorIgnored() {
+        val leather = Item("Leather Armor", type = "armor", ac = 11, equipped = false)
+        val ch = char(leather, abilities = Abilities(dex = 14))
+        assertEquals(12, EquipmentEffects.effectiveAc(ch))
+    }
+
+    @Test fun effectiveAc_usesEffectiveDex() {
+        // Cloak of Dex +2 feeds into the unarmored AC calc.
+        val cloak = Item("Cloak of Dex", type = "clothes", equipped = true,
+            effects = listOf(ItemEffect.AbilityBonus("DEX", 2)))
+        val ch = char(cloak, abilities = Abilities(dex = 14))
+        assertEquals(13, EquipmentEffects.effectiveAc(ch)) // 10 + (14+2)/2-5 = 10+3
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `gradle :app:testDebugUnitTest --tests "com.realmsoffate.game.game.EquipmentEffectsTest"`
+Expected: FAIL — `effectiveAc` unresolved.
+
+- [ ] **Step 3: Add `effectiveAc` to `EquipmentEffects.kt`**
+
+Append inside the `EquipmentEffects` object:
+
+```kotlin
+    /** Names whose presence disables the DEX contribution to AC. */
+    private val HEAVY_ARMOR_TOKENS = listOf("Chain Mail", "Plate", "Ring Mail", "Splint")
+
+    fun effectiveAc(ch: Character): Int {
+        val eq = ch.inventory.filter { it.equipped }
+        val armor = eq.firstOrNull { it.ac != null }
+        val hasShield = eq.any { it.type.equals("shield", ignoreCase = true) }
+        val effDex = effectiveAbilities(ch).dexMod
+        val base = if (armor == null) 10 + effDex
+            else if (HEAVY_ARMOR_TOKENS.any { armor.name.contains(it, ignoreCase = true) }) armor.ac!!
+            else armor.ac!! + effDex
+        return base + if (hasShield) 2 else 0
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `gradle :app:testDebugUnitTest --tests "com.realmsoffate.game.game.EquipmentEffectsTest"`
+Expected: PASS (all 12 tests now).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/kotlin/com/realmsoffate/game/game/EquipmentEffects.kt \
+        app/src/test/kotlin/com/realmsoffate/game/game/EquipmentEffectsTest.kt
+git commit -m "feat(equipment): EquipmentEffects.effectiveAc (shields + heavy armor DEX rule)"
+```
+
+---
+
+## Task 4: `effectiveMaxHp` + `skillBonuses` + `resistances`/`immunities` + `onHitRiders` + `passiveTriggers`
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/realmsoffate/game/game/EquipmentEffects.kt`
+- Test: `app/src/test/kotlin/com/realmsoffate/game/game/EquipmentEffectsTest.kt`
+
+- [ ] **Step 1: Append failing tests**
+
+```kotlin
+    @Test fun effectiveMaxHp_addsMaxHpBonuses() {
+        val amulet = Item("Amulet of Health", equipped = true,
+            effects = listOf(ItemEffect.MaxHpBonus(5)))
+        val ch = char(amulet).copy(maxHp = 20)
+        assertEquals(25, EquipmentEffects.effectiveMaxHp(ch))
+    }
+
+    @Test fun effectiveMaxHp_ignoresUnequipped() {
+        val amulet = Item("Amulet of Health", equipped = false,
+            effects = listOf(ItemEffect.MaxHpBonus(5)))
+        val ch = char(amulet).copy(maxHp = 20)
+        assertEquals(20, EquipmentEffects.effectiveMaxHp(ch))
+    }
+
+    @Test fun skillBonuses_sumsByCanonicalKey() {
+        val boots = Item("Boots of Stealth", equipped = true,
+            effects = listOf(ItemEffect.SkillBonus("Stealth", 2)))
+        val cloak = Item("Shadow Cloak", equipped = true,
+            effects = listOf(ItemEffect.SkillBonus("stealth", 1), ItemEffect.SkillBonus("Perception", 1)))
+        val ch = char(boots, cloak)
+        val b = EquipmentEffects.skillBonuses(ch)
+        assertEquals(3, b["Stealth"])
+        assertEquals(1, b["Perception"])
+    }
+
+    @Test fun resistances_setOfLowercaseDamageTypes() {
+        val ring1 = Item("R1", equipped = true, effects = listOf(ItemEffect.Resistance("Fire")))
+        val ring2 = Item("R2", equipped = true, effects = listOf(ItemEffect.Resistance("fire"), ItemEffect.Resistance("cold")))
+        val ch = char(ring1, ring2)
+        assertEquals(setOf("fire", "cold"), EquipmentEffects.resistances(ch))
+    }
+
+    @Test fun immunities_onlyFromImmunityEffects() {
+        val ring = Item("R", equipped = true,
+            effects = listOf(ItemEffect.Immunity("poison"), ItemEffect.Resistance("fire")))
+        val ch = char(ring)
+        assertEquals(setOf("poison"), EquipmentEffects.immunities(ch))
+        assertEquals(setOf("fire"), EquipmentEffects.resistances(ch))
+    }
+
+    @Test fun onHitRiders_orderPreserved() {
+        val sword = Item("Flametongue", equipped = true,
+            effects = listOf(ItemEffect.OnHit("1d6", "fire"), ItemEffect.OnHit("1d4", "radiant")))
+        val ring = Item("Thunder Ring", equipped = true,
+            effects = listOf(ItemEffect.OnHit("1d4", "thunder")))
+        val ch = char(sword, ring)
+        val riders = EquipmentEffects.onHitRiders(ch)
+        assertEquals(3, riders.size)
+        assertEquals("fire", riders[0].damageType)
+        assertEquals("radiant", riders[1].damageType)
+        assertEquals("thunder", riders[2].damageType)
+    }
+
+    @Test fun passiveTriggers_returnsText() {
+        val cursed = Item("Cursed Ring", equipped = true,
+            effects = listOf(ItemEffect.PassiveTrigger("cursed: -1 to all rolls")))
+        val vorpal = Item("Vorpal Sword", equipped = true,
+            effects = listOf(ItemEffect.PassiveTrigger("vorpal: on nat 20, narrate decapitation")))
+        val ch = char(cursed, vorpal)
+        val texts = EquipmentEffects.passiveTriggers(ch)
+        assertEquals(2, texts.size)
+        assertTrue(texts.any { it.startsWith("cursed") })
+        assertTrue(texts.any { it.startsWith("vorpal") })
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `gradle :app:testDebugUnitTest --tests "com.realmsoffate.game.game.EquipmentEffectsTest"`
+Expected: FAIL — 5 new helpers unresolved.
+
+- [ ] **Step 3: Add the helpers**
+
+Append inside the `EquipmentEffects` object:
+
+```kotlin
+    fun effectiveMaxHp(ch: Character): Int =
+        ch.maxHp + activeEffects(ch).filterIsInstance<ItemEffect.MaxHpBonus>().sumOf { it.amount }
+
+    fun skillBonuses(ch: Character): Map<String, Int> {
+        val out = LinkedHashMap<String, Int>()
+        activeEffects(ch).filterIsInstance<ItemEffect.SkillBonus>().forEach { e ->
+            val key = e.skill.trim().replaceFirstChar { c -> c.uppercaseChar() }
+                .let { if (it.length > 1) it[0] + it.substring(1).lowercase() else it }
+            out[key] = (out[key] ?: 0) + e.amount
+        }
+        return out
+    }
+
+    fun resistances(ch: Character): Set<String> =
+        activeEffects(ch).filterIsInstance<ItemEffect.Resistance>()
+            .map { it.damageType.lowercase() }.toSet()
+
+    fun immunities(ch: Character): Set<String> =
+        activeEffects(ch).filterIsInstance<ItemEffect.Immunity>()
+            .map { it.damageType.lowercase() }.toSet()
+
+    fun onHitRiders(ch: Character): List<ItemEffect.OnHit> =
+        activeEffects(ch).filterIsInstance<ItemEffect.OnHit>()
+
+    fun passiveTriggers(ch: Character): List<String> =
+        activeEffects(ch).filterIsInstance<ItemEffect.PassiveTrigger>().map { it.text }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `gradle :app:testDebugUnitTest --tests "com.realmsoffate.game.game.EquipmentEffectsTest"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/kotlin/com/realmsoffate/game/game/EquipmentEffects.kt \
+        app/src/test/kotlin/com/realmsoffate/game/game/EquipmentEffectsTest.kt
+git commit -m "feat(equipment): effectiveMaxHp, skillBonuses, resistances, immunities, onHit, triggers"
+```
+
+---
+
+## Task 5: `promptSummary`
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/realmsoffate/game/game/EquipmentEffects.kt`
+- Test: `app/src/test/kotlin/com/realmsoffate/game/game/PromptSummaryTest.kt`
+
+- [ ] **Step 1: Write failing test**
+
+Create `app/src/test/kotlin/com/realmsoffate/game/game/PromptSummaryTest.kt`:
+
+```kotlin
+package com.realmsoffate.game.game
+
+import com.realmsoffate.game.data.Abilities
+import com.realmsoffate.game.data.Character
+import com.realmsoffate.game.data.Item
+import com.realmsoffate.game.data.ItemEffect
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PromptSummaryTest {
+
+    private fun char(vararg items: Item): Character =
+        Character(name = "T", race = "Human", cls = "Fighter",
+            abilities = Abilities(), inventory = items.toMutableList())
+
+    @Test fun empty_whenNoEquippedWithEffects() {
+        val ch = char(Item("Apple", type = "consumable"))
+        assertEquals("", EquipmentEffects.promptSummary(ch))
+    }
+
+    @Test fun rendersWeaponsArmorAbilitySkillResistOnHitTrigger() {
+        val sword = Item("Flametongue", type = "weapon", damage = "1d8", equipped = true,
+            effects = listOf(ItemEffect.OnHit("1d6", "fire")))
+        val plate = Item("Plate Armor", type = "armor", ac = 18, equipped = true)
+        val ringStr = Item("Ring of Strength", type = "ring", equipped = true,
+            effects = listOf(ItemEffect.AbilityBonus("STR", 2)))
+        val cloak = Item("Cloak of Stealth", type = "clothes", equipped = true,
+            effects = listOf(ItemEffect.SkillBonus("Stealth", 2)))
+        val ringFire = Item("Fire Resist Ring", type = "ring", equipped = true,
+            effects = listOf(ItemEffect.Resistance("fire")))
+        val amulet = Item("Amulet of Antivenom", type = "amulet", equipped = true,
+            effects = listOf(ItemEffect.Immunity("poison")))
+        val cursed = Item("Cursed Ring", type = "ring", equipped = true,
+            effects = listOf(ItemEffect.PassiveTrigger("cursed: -1 to all rolls")))
+        val ch = char(sword, plate, ringStr, cloak, ringFire, amulet, cursed)
+        val out = EquipmentEffects.promptSummary(ch)
+        assertTrue("heading present", out.startsWith("Equipped gear:"))
+        assertTrue("weapon line", out.contains("Flametongue") && out.contains("1d8"))
+        assertTrue("on-hit", out.contains("on hit: +1d6 fire"))
+        assertTrue("armor line", out.contains("Plate Armor") && out.contains("AC 18"))
+        assertTrue("ability bonus marked applied", out.contains("+2 STR") && out.contains("applied"))
+        assertTrue("skill bonus", out.contains("+2 Stealth"))
+        assertTrue("resistances line", out.contains("Resistances: fire"))
+        assertTrue("immunities line", out.contains("Immunities: poison"))
+        assertTrue("passive trigger", out.contains("cursed: -1 to all rolls"))
+    }
+
+    @Test fun skipsItemsWithNoEffectsAndNoStatFields() {
+        // A plain equipped widget should not be rendered at all.
+        val trinket = Item("Lucky Coin", type = "item", equipped = true)
+        assertEquals("", EquipmentEffects.promptSummary(char(trinket)))
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `gradle :app:testDebugUnitTest --tests "com.realmsoffate.game.game.PromptSummaryTest"`
+Expected: FAIL — `promptSummary` unresolved.
+
+- [ ] **Step 3: Add `promptSummary`**
+
+Append inside the `EquipmentEffects` object:
+
+```kotlin
+    fun promptSummary(ch: Character): String {
+        val eq = ch.inventory.filter { it.equipped }
+        val interesting = eq.filter { it.damage != null || it.ac != null || it.effects.isNotEmpty() }
+        if (interesting.isEmpty() && resistances(ch).isEmpty() && immunities(ch).isEmpty())
+            return ""
+        val sb = StringBuilder()
+        sb.appendLine("Equipped gear:")
+        interesting.forEach { item ->
+            val head = buildString {
+                append("- ")
+                append(item.name)
+                append(" (")
+                append(item.type)
+                if (item.damage != null) append(", ${item.damage}")
+                if (item.ac != null) append(", AC ${item.ac}")
+                append(")")
+            }
+            sb.append(head)
+            val extras = mutableListOf<String>()
+            item.effects.forEach { e ->
+                when (e) {
+                    is ItemEffect.AbilityBonus -> extras.add("${signed(e.amount)} ${e.stat.uppercase()} (applied)")
+                    is ItemEffect.SkillBonus   -> extras.add("${signed(e.amount)} ${e.skill} checks")
+                    is ItemEffect.Resistance   -> { /* rolled up below */ }
+                    is ItemEffect.Immunity     -> { /* rolled up below */ }
+                    is ItemEffect.OnHit        -> extras.add("on hit: +${e.dice} ${e.damageType}")
+                    is ItemEffect.MaxHpBonus   -> extras.add("${signed(e.amount)} max HP")
+                    is ItemEffect.PassiveTrigger -> extras.add("passive: ${e.text}")
+                }
+            }
+            if (extras.isNotEmpty()) sb.append(" — ").append(extras.joinToString("; "))
+            sb.append('\n')
+        }
+        val res = resistances(ch)
+        if (res.isNotEmpty()) sb.appendLine("Resistances: ${res.sorted().joinToString(", ")}")
+        val imm = immunities(ch)
+        if (imm.isNotEmpty()) sb.appendLine("Immunities: ${imm.sorted().joinToString(", ")}")
+        return sb.toString().trimEnd()
+    }
+
+    private fun signed(n: Int): String = if (n >= 0) "+$n" else "$n"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `gradle :app:testDebugUnitTest --tests "com.realmsoffate.game.game.PromptSummaryTest"`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/kotlin/com/realmsoffate/game/game/EquipmentEffects.kt \
+        app/src/test/kotlin/com/realmsoffate/game/game/PromptSummaryTest.kt
+git commit -m "feat(equipment): promptSummary renders equipped gear for LLM prompt"
+```
+
+---
+
+## Task 6: Wire `effectiveAc` into `Classes.applyClassStart`
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/realmsoffate/game/game/Classes.kt`
+
+- [ ] **Step 1: Add a regression test for class start AC**
+
+Append to `app/src/test/kotlin/com/realmsoffate/game/game/EquipmentEffectsTest.kt`:
+
+```kotlin
+    @Test fun applyClassStart_setsAcViaEffectiveAc() {
+        val ch = Character(name = "T", race = "Human", cls = "Fighter",
+            abilities = Abilities(dex = 14, con = 12))
+        val cls = Classes.find("Fighter")!!
+        applyClassStart(ch, cls)
+        // Fighter starts with Chain Mail (heavy, AC 16, no DEX) + Shield (+2).
+        assertEquals(18, ch.ac)
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `gradle :app:testDebugUnitTest --tests "com.realmsoffate.game.game.EquipmentEffectsTest.applyClassStart_setsAcViaEffectiveAc"`
+Expected: FAIL — likely mismatched AC because current logic at lines 199-201 doesn't add shield correctly, or does, depending on name match. Confirm the actual failure before writing the fix.
+
+- [ ] **Step 3: Replace lines 199-201 in `Classes.kt` with EquipmentEffects call**
+
+In `app/src/main/kotlin/com/realmsoffate/game/game/Classes.kt`, change `applyClassStart` (lines 194-203):
+
+```kotlin
+fun applyClassStart(ch: Character, cls: ClassDef) {
+    ch.maxHp = Classes.rollHp(cls.name, ch.abilities.con)
+    ch.hp = ch.maxHp
+    ch.inventory.clear()
+    ch.inventory.addAll(cls.startingItems.map { it.copy() })
+    ch.ac = EquipmentEffects.effectiveAc(ch)
+    if (cls.isCaster) Spells.grantStartingSpells(ch, cls)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `gradle :app:testDebugUnitTest --tests "com.realmsoffate.game.game.EquipmentEffectsTest"`
+Expected: PASS (all EquipmentEffectsTest tests, including `applyClassStart_setsAcViaEffectiveAc`).
+
+Also run the full suite to catch regressions:
+
+Run: `gradle :app:testDebugUnitTest`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/kotlin/com/realmsoffate/game/game/Classes.kt \
+        app/src/test/kotlin/com/realmsoffate/game/game/EquipmentEffectsTest.kt
+git commit -m "refactor(classes): applyClassStart delegates AC to EquipmentEffects.effectiveAc"
+```
+
+---
+
+## Task 7: `equipToggle` recomputes AC + maxHP delta + HP clamp
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/realmsoffate/game/game/GameViewModel.kt`
+- Test: `app/src/test/kotlin/com/realmsoffate/game/game/EquipToggleEffectsTest.kt`
+
+Note: `equipToggle` is not trivially testable without a VM harness. We'll extract the pure recomputation logic into a helper on `EquipmentEffects` and test that directly. The VM method will just call it.
+
+- [ ] **Step 1: Write failing test for the pure helper**
+
+Create `app/src/test/kotlin/com/realmsoffate/game/game/EquipToggleEffectsTest.kt`:
+
+```kotlin
+package com.realmsoffate.game.game
+
+import com.realmsoffate.game.data.Abilities
+import com.realmsoffate.game.data.Character
+import com.realmsoffate.game.data.Item
+import com.realmsoffate.game.data.ItemEffect
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class EquipToggleEffectsTest {
+
+    private fun baseCharacter(vararg items: Item): Character =
+        Character(name = "T", race = "Human", cls = "Fighter",
+            abilities = Abilities(dex = 14), maxHp = 20, hp = 20, ac = 12,
+            inventory = items.toMutableList())
+
+    @Test fun equippingAmulet_raisesMaxHp_doesNotHealCurrent() {
+        val amulet = Item("Amulet of Health", type = "amulet", equipped = false,
+            effects = listOf(ItemEffect.MaxHpBonus(5)))
+        val ch = baseCharacter(amulet).copy(hp = 18)
+        val (maxHp, hp) = EquipmentEffects.recalcHpAfterEquip(
+            oldChar = ch,
+            newChar = ch.copy(inventory = mutableListOf(amulet.copy(equipped = true)))
+        )
+        assertEquals(25, maxHp)
+        assertEquals(18, hp) // unchanged
+    }
+
+    @Test fun unequippingAmulet_dropsMaxHp_clampsHp() {
+        val amulet = Item("Amulet of Health", type = "amulet", equipped = true,
+            effects = listOf(ItemEffect.MaxHpBonus(5)))
+        // Character has amulet already worked into maxHp=25, hp=25.
+        val ch = baseCharacter(amulet).copy(maxHp = 25, hp = 25)
+        val (maxHp, hp) = EquipmentEffects.recalcHpAfterEquip(
+            oldChar = ch,
+            newChar = ch.copy(inventory = mutableListOf(amulet.copy(equipped = false)))
+        )
+        assertEquals(20, maxHp)
+        assertEquals(20, hp) // clamped down
+    }
+
+    @Test fun unequippingAmulet_whenAlreadyWounded_keepsWoundedHp() {
+        val amulet = Item("Amulet of Health", type = "amulet", equipped = true,
+            effects = listOf(ItemEffect.MaxHpBonus(5)))
+        val ch = baseCharacter(amulet).copy(maxHp = 25, hp = 12)
+        val (maxHp, hp) = EquipmentEffects.recalcHpAfterEquip(
+            oldChar = ch,
+            newChar = ch.copy(inventory = mutableListOf(amulet.copy(equipped = false)))
+        )
+        assertEquals(20, maxHp)
+        assertEquals(12, hp)
+    }
+
+    @Test fun equipSwap_betweenArmorPieces_changesAcLive() {
+        val leather = Item("Leather Armor", type = "armor", ac = 11, equipped = true)
+        val plate = Item("Plate Armor", type = "armor", ac = 18, equipped = false)
+        val ch = baseCharacter(leather, plate).copy(ac = 13) // 11 + dex 2
+        val newCh = ch.copy(inventory = mutableListOf(
+            leather.copy(equipped = false),
+            plate.copy(equipped = true)
+        ))
+        val newAc = EquipmentEffects.effectiveAc(newCh)
+        assertEquals(18, newAc) // plate ignores dex
+    }
+
+    @Test fun abilityBonus_reflectedInEffectiveAbilities_notBase() {
+        val ring = Item("Ring of Strength", type = "ring", equipped = true,
+            effects = listOf(ItemEffect.AbilityBonus("STR", 2)))
+        val ch = baseCharacter(ring).copy(abilities = Abilities(str = 14))
+        assertEquals(14, ch.abilities.str) // base untouched
+        assertEquals(16, EquipmentEffects.effectiveAbilities(ch).str)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `gradle :app:testDebugUnitTest --tests "com.realmsoffate.game.game.EquipToggleEffectsTest"`
+Expected: FAIL — `EquipmentEffects.recalcHpAfterEquip` unresolved.
+
+- [ ] **Step 3: Add `recalcHpAfterEquip` to `EquipmentEffects.kt`**
+
+Append inside the `EquipmentEffects` object:
+
+```kotlin
+    /**
+     * Given the character before and after an equip-state change, return the (newMaxHp, newHp)
+     * pair that should be written back. Bases the delta on MaxHpBonus effects, preserves wounds
+     * (never heals on equip), and clamps down on unequip.
+     */
+    fun recalcHpAfterEquip(oldChar: Character, newChar: Character): Pair<Int, Int> {
+        val oldBonus = oldChar.inventory.filter { it.equipped }
+            .flatMap { it.effects }.filterIsInstance<ItemEffect.MaxHpBonus>().sumOf { it.amount }
+        val newBonus = newChar.inventory.filter { it.equipped }
+            .flatMap { it.effects }.filterIsInstance<ItemEffect.MaxHpBonus>().sumOf { it.amount }
+        val delta = newBonus - oldBonus
+        val newMax = (oldChar.maxHp + delta).coerceAtLeast(1)
+        val newHp = oldChar.hp.coerceAtMost(newMax)
+        return newMax to newHp
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `gradle :app:testDebugUnitTest --tests "com.realmsoffate.game.game.EquipToggleEffectsTest"`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Wire into `GameViewModel.equipToggle`**
+
+In `app/src/main/kotlin/com/realmsoffate/game/game/GameViewModel.kt`, modify `equipToggle` (lines 1645-1675). Replace the final two lines (`_ui.value = s.copy(...)` and what follows) so the method ends like this:
+
+```kotlin
+        inv[idx] = inv[idx].copy(equipped = nowEquipped)
+        val newCh = ch.copy(inventory = inv)
+        val (newMaxHp, newHp) = EquipmentEffects.recalcHpAfterEquip(oldChar = ch, newChar = newCh)
+        val newAc = EquipmentEffects.effectiveAc(newCh)
+        _ui.value = s.copy(character = newCh.copy(maxHp = newMaxHp, hp = newHp, ac = newAc))
+        val action = when {
+            !nowEquipped -> "I unequip my ${item.name}"
+            displaced.isEmpty() -> "I equip my ${item.name}"
+            else -> "I unequip my ${displaced.joinToString(" and ")} and equip my ${item.name}"
+        }
+        submitAction(action)
+    }
+```
+
+Make sure to add the import at the top of the file:
+
+```kotlin
+import com.realmsoffate.game.game.EquipmentEffects
+```
+
+(If the file is already in package `com.realmsoffate.game.game`, the import is not needed — same-package access.)
+
+- [ ] **Step 6: Rerun tests**
+
+Run: `gradle :app:testDebugUnitTest`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/src/main/kotlin/com/realmsoffate/game/game/EquipmentEffects.kt \
+        app/src/main/kotlin/com/realmsoffate/game/game/GameViewModel.kt \
+        app/src/test/kotlin/com/realmsoffate/game/game/EquipToggleEffectsTest.kt
+git commit -m "feat(equipment): equipToggle recomputes AC + maxHp delta + HP clamp"
+```
+
+---
+
+## Task 8: Swap ability-check sites to effective abilities
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/realmsoffate/game/game/GameViewModel.kt`
+
+- [ ] **Step 1: Read the three ability-check sites**
+
+Sites: lines 833, 857, 913. Each currently reads `char.abilities.modByName(ability)`. We want `EquipmentEffects.effectiveAbilities(char).modByName(ability)`.
+
+- [ ] **Step 2: Replace at line 833**
+
+In `GameViewModel.kt` replace (line ~833):
+
+```kotlin
+val mod = char.abilities.modByName(ability)
+```
+
+with:
+
+```kotlin
+val mod = EquipmentEffects.effectiveAbilities(char).modByName(ability)
+```
+
+- [ ] **Step 3: Replace at line 857**
+
+Same edit at line 857.
+
+- [ ] **Step 4: Replace at line 913**
+
+Same edit at line 913.
+
+- [ ] **Step 5: Also update `/describe` stat print at line 423**
+
+Replace line 423 with:
+
+```kotlin
+val effAb = EquipmentEffects.effectiveAbilities(ch)
+appendLine("STR:${effAb.str} DEX:${effAb.dex} CON:${effAb.con} INT:${effAb.int} WIS:${effAb.wis} CHA:${effAb.cha}")
+```
+
+- [ ] **Step 6: Build + run tests**
+
+Run: `gradle :app:testDebugUnitTest`
+Expected: PASS (no new tests — this is a routing change).
+
+Run: `gradle :app:assembleDebug`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/src/main/kotlin/com/realmsoffate/game/game/GameViewModel.kt
+git commit -m "refactor(checks): ability math reads EquipmentEffects.effectiveAbilities"
+```
+
+---
+
+## Task 9: Emit `promptSummary` in LLM prompt
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/realmsoffate/game/game/GameViewModel.kt`
+
+- [ ] **Step 1: Replace line 427**
+
+Current:
+
+```kotlin
+appendLine("Equipped: ${ch.inventory.filter { it.equipped }.joinToString(", ") { it.name }.ifBlank { "nothing" }}")
+```
+
+Replace with:
+
+```kotlin
+val gearSummary = EquipmentEffects.promptSummary(ch)
+if (gearSummary.isBlank()) appendLine("Equipped: nothing")
+else { appendLine(); appendLine(gearSummary) }
+```
+
+- [ ] **Step 2: Replace line 1180**
+
+Current:
+
+```kotlin
+val inv = ch.inventory.filter { it.equipped }.joinToString(", ") { it.name }.ifBlank { "nothing" }
+```
+
+Find the `appendLine` or concatenation that uses `inv` and replace the whole segment with an equivalent block that emits `EquipmentEffects.promptSummary(ch)` in the same way — the surrounding prompt format at this site is the second LLM call. Keep the caller's existing "Equipped: ..." fallback phrasing if the summary is blank.
+
+The concrete edit: read around line 1180 for 15 lines of context, locate the nearest sink (`appendLine`, `+`, `"""..."""` interpolation) that uses `inv`, and substitute:
+
+```kotlin
+val gear = EquipmentEffects.promptSummary(ch).ifBlank { "Equipped: nothing" }
+```
+
+…then interpolate `$gear` where `$inv` was used.
+
+- [ ] **Step 3: Build**
+
+Run: `gradle :app:assembleDebug`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Run all tests**
+
+Run: `gradle :app:testDebugUnitTest`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/kotlin/com/realmsoffate/game/game/GameViewModel.kt
+git commit -m "feat(prompt): send EquipmentEffects.promptSummary to LLM in both prompt sites"
+```
+
+---
+
+## Task 10: LLM loot schema — extend `items_gained` with `effects`
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/realmsoffate/game/data/Prompts.kt`
+- Test: `app/src/test/kotlin/com/realmsoffate/game/data/ItemSpecEffectsParseTest.kt`
+
+- [ ] **Step 1: Write failing test**
+
+Create `app/src/test/kotlin/com/realmsoffate/game/data/ItemSpecEffectsParseTest.kt`:
+
+```kotlin
+package com.realmsoffate.game.data
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ItemSpecEffectsParseTest {
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+    @Test fun itemSpec_parsesEffectsArray() {
+        val raw = """
+        {
+          "name": "Ring of Fire Resistance",
+          "desc": "Shimmers with heat.",
+          "type": "ring",
+          "rarity": "uncommon",
+          "effects": [
+            {"type":"resist","damageType":"fire"}
+          ]
+        }
+        """.trimIndent()
+        val spec = json.decodeFromString(ItemSpec.serializer(), raw)
+        assertEquals("Ring of Fire Resistance", spec.name)
+        assertEquals(1, spec.effects.size)
+        val e = spec.effects[0]
+        assertTrue(e is ItemEffect.Resistance)
+        assertEquals("fire", (e as ItemEffect.Resistance).damageType)
+    }
+
+    @Test fun itemSpec_absentEffects_defaultsEmpty() {
+        val raw = """{"name":"Apple","type":"consumable"}"""
+        val spec = json.decodeFromString(ItemSpec.serializer(), raw)
+        assertTrue(spec.effects.isEmpty())
+    }
+
+    @Test fun itemSpec_multipleEffects() {
+        val raw = """
+        {
+          "name": "Flametongue",
+          "type": "weapon",
+          "effects": [
+            {"type":"onhit","dice":"1d6","damageType":"fire"},
+            {"type":"ability","stat":"CHA","amount":1}
+          ]
+        }
+        """.trimIndent()
+        val spec = json.decodeFromString(ItemSpec.serializer(), raw)
+        assertEquals(2, spec.effects.size)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `gradle :app:testDebugUnitTest --tests "com.realmsoffate.game.data.ItemSpecEffectsParseTest"`
+Expected: PASS (ItemSpec already has effects from Task 1 — this test locks the parse behavior).
+
+- [ ] **Step 3: Update the prompt schema at `Prompts.kt:221`**
+
+Current (line 221):
+
+```kotlin
+    "items_gained": [{"name":"","desc":"","type":"weapon|armor|shield|amulet|ring|clothes|consumable|item","rarity":"common|uncommon|rare|epic|legendary"}],
+```
+
+Replace with:
+
+```kotlin
+    "items_gained": [{"name":"","desc":"","type":"weapon|armor|shield|amulet|ring|clothes|consumable|item","rarity":"common|uncommon|rare|epic|legendary","effects":[
+        // ZERO OR MORE of any of:
+        //   {"type":"ability","stat":"STR|DEX|CON|INT|WIS|CHA","amount":1},
+        //   {"type":"skill","skill":"Stealth","amount":2},
+        //   {"type":"resist","damageType":"fire"},
+        //   {"type":"immune","damageType":"poison"},
+        //   {"type":"onhit","dice":"1d4","damageType":"fire"},
+        //   {"type":"maxhp","amount":5},
+        //   {"type":"trigger","text":"cursed: -1 to all rolls"}
+    ]}],
+```
+
+- [ ] **Step 4: Add narrator guidance about equipped gear**
+
+Near the existing "Mechanical side effects go in the "metadata" object" line (~line 277), add a new paragraph — check nearby lines first to place it naturally:
+
+```text
+EQUIPPED GEAR (see the "Equipped gear:" block in the character context):
+- Ability bonuses from equipped items are ALREADY folded into the STR/DEX/CON/INT/WIS/CHA scores you see. Do not re-apply them to checks or saves.
+- Skill bonuses are NOT folded in — add them to the relevant skill check roll.
+- Resistances halve incoming damage of that type. Immunities negate it entirely.
+- On-hit riders add their damage to successful weapon attacks — narrate and include the rider damage in your numbers.
+- Passive-trigger text is narrative law: honor it exactly as written for the duration the item is equipped.
+```
+
+Find a free spot in the narrator-instructions text (search for existing guidance around metadata / numeric rules) and insert the block. It does not need to replace any existing text — it's additive.
+
+- [ ] **Step 5: Build + test**
+
+Run: `gradle :app:testDebugUnitTest`
+Expected: PASS.
+
+Run: `gradle :app:assembleDebug`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/kotlin/com/realmsoffate/game/data/Prompts.kt \
+        app/src/test/kotlin/com/realmsoffate/game/data/ItemSpecEffectsParseTest.kt
+git commit -m "feat(prompt): LLM loot schema + narrator rules for equipped effects"
+```
+
+---
+
+## Task 11: Carry `ItemSpec.effects` onto materialized `Item`
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/realmsoffate/game/game/GameViewModel.kt` (or reducer — whichever file materializes `items_gained`)
+
+- [ ] **Step 1: Find the materialization site**
+
+Run: `grep -n "items_gained\|itemsGained" app/src/main/kotlin/com/realmsoffate/game/game/GameViewModel.kt app/src/main/kotlin/com/realmsoffate/game/game/reducers/*.kt app/src/main/kotlin/com/realmsoffate/game/game/handlers/*.kt`
+
+There will be a spot that constructs `Item(name = spec.name, desc = spec.desc, type = spec.type, rarity = spec.rarity, ...)`. Record the file path and line.
+
+- [ ] **Step 2: Write a failing test**
+
+Append to `app/src/test/kotlin/com/realmsoffate/game/data/ItemSpecEffectsParseTest.kt`:
+
+```kotlin
+    @Test fun itemSpecToItem_preservesEffects() {
+        val spec = ItemSpec(
+            name = "Ring of Fire Resistance",
+            type = "ring",
+            effects = listOf(ItemEffect.Resistance("fire"))
+        )
+        // Direct construction mirrors what the reducer should do.
+        val item = Item(name = spec.name, desc = spec.desc, type = spec.type,
+            rarity = spec.rarity, effects = spec.effects)
+        assertEquals(1, item.effects.size)
+        assertTrue(item.effects[0] is ItemEffect.Resistance)
+    }
+```
+
+- [ ] **Step 3: Run and confirm pass** (the test is a property of the data class — it passes immediately, but it documents the contract the reducer must honor).
+
+Run: `gradle :app:testDebugUnitTest --tests "com.realmsoffate.game.data.ItemSpecEffectsParseTest.itemSpecToItem_preservesEffects"`
+Expected: PASS.
+
+- [ ] **Step 4: Update the materialization site**
+
+At the file/line found in Step 1, ensure the `Item(...)` constructor call receives `effects = spec.effects`. Example fix:
+
+```kotlin
+// Before:
+Item(name = spec.name, desc = spec.desc, type = spec.type, rarity = spec.rarity)
+// After:
+Item(name = spec.name, desc = spec.desc, type = spec.type, rarity = spec.rarity, effects = spec.effects)
+```
+
+- [ ] **Step 5: Build**
+
+Run: `gradle :app:assembleDebug && gradle :app:testDebugUnitTest`
+Expected: BUILD SUCCESSFUL, tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add <file-modified-in-step-4> \
+        app/src/test/kotlin/com/realmsoffate/game/data/ItemSpecEffectsParseTest.kt
+git commit -m "feat(loot): carry ItemSpec.effects onto player Item on items_gained"
+```
+
+---
+
+## Task 12: Inventory UI — show effects on selected item
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/realmsoffate/game/ui/panels/InventoryPage.kt`
+
+- [ ] **Step 1: Locate `SelectedItemCard`**
+
+It's at `InventoryPage.kt:253` approximately. There's a block (around line 234) that already shows `AC X` / `damage` if present.
+
+- [ ] **Step 2: Add effects rendering**
+
+Inside the card, after the existing AC/damage Texts and before the action buttons, add:
+
+```kotlin
+if (item.effects.isNotEmpty()) {
+    Spacer(Modifier.height(4.dp))
+    item.effects.forEach { e ->
+        val line = when (e) {
+            is ItemEffect.AbilityBonus -> "${if (e.amount >= 0) "+${e.amount}" else "${e.amount}"} ${e.stat.uppercase()}"
+            is ItemEffect.SkillBonus   -> "${if (e.amount >= 0) "+${e.amount}" else "${e.amount}"} ${e.skill}"
+            is ItemEffect.Resistance   -> "Resist ${e.damageType}"
+            is ItemEffect.Immunity     -> "Immune ${e.damageType}"
+            is ItemEffect.OnHit        -> "On hit: +${e.dice} ${e.damageType}"
+            is ItemEffect.MaxHpBonus   -> "${if (e.amount >= 0) "+${e.amount}" else "${e.amount}"} max HP"
+            is ItemEffect.PassiveTrigger -> e.text
+        }
+        Text(line, style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+}
+```
+
+Add the import at the top of the file:
+
+```kotlin
+import com.realmsoffate.game.data.ItemEffect
+```
+
+- [ ] **Step 3: Deploy and smoke-test**
+
+Run: `gradle installDebug && adb -s emulator-5554 shell am start -n com.realmsoffate.game/.MainActivity && adb -s emulator-5554 forward tcp:8735 tcp:8735`
+
+Open inventory, equip a test item with effects (use debug bridge to inject one) and confirm the effect lines render.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/kotlin/com/realmsoffate/game/ui/panels/InventoryPage.kt
+git commit -m "feat(inventory-ui): render equipment effect list on selected item"
+```
+
+---
+
+## Task 13: Integration sanity + full-suite green
+
+**Files:** (verification only)
+
+- [ ] **Step 1: Full unit suite**
+
+Run: `gradle test`
+Expected: All tests PASS. No skipped or ignored.
+
+- [ ] **Step 2: Lint**
+
+Run: `gradle lint`
+Expected: No new errors introduced (warnings from pre-existing code are acceptable).
+
+- [ ] **Step 3: Smoke test on emulator**
+
+- Equip a weapon, armor, and shield — confirm AC updates live in the UI.
+- Use debug bridge to inject an item with `MaxHpBonus(5)`; equip it; confirm maxHp rises by 5 and HP bar does not auto-heal.
+- Unequip it while wounded; confirm maxHp drops and current HP is preserved (not clamped up).
+- Use debug bridge to inject an item with `AbilityBonus("STR", 2)`; confirm `/describe` shows boosted STR.
+
+- [ ] **Step 4: Final commit (docs touch-up or nothing)**
+
+If any spec/plan edits surfaced during execution, commit them. Otherwise no final commit is required.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- ✅ #1 Weapon damage — LLM-informed via `promptSummary` weapon line (Tasks 5, 9).
+- ✅ #2 AC / shield — `effectiveAc` + `applyClassStart` + `equipToggle` (Tasks 3, 6, 7).
+- ✅ #3 Ability bonuses — `effectiveAbilities` + call-site swap (Tasks 2, 8).
+- ✅ #4 Skill bonuses — `skillBonuses` + prompt summary + narrator guidance (Tasks 4, 5, 10).
+- ✅ #5 Resistances/immunities — `resistances`/`immunities` + prompt rollup + narrator rule (Tasks 4, 5, 10).
+- ✅ #6 On-hit / passive triggers — `onHitRiders` + `passiveTriggers` + prompt + narrator rule (Tasks 4, 5, 10).
+- ✅ #7 MaxHP — `effectiveMaxHp` + `recalcHpAfterEquip` + equipToggle wire-in (Tasks 4, 7).
+- ✅ Tests for all seven — EquipmentEffectsTest, EquipToggleEffectsTest, PromptSummaryTest, ItemEffectSerializationTest, ItemSpecEffectsParseTest.
+- ✅ UI — Task 12.
+- ✅ LLM schema + narrator rules — Task 10.
+- ✅ Migration — default-empty `effects` field means old saves load.
+
+**Placeholder scan:** No TBD/TODO/vague-error-handling language. Only one placeholder-style reference: Task 11 Step 1 asks the engineer to grep for the materialization site because it may live in one of several reducer files. The grep command is exact and the expected change is a one-line constructor addition shown in Step 4.
+
+**Type consistency:** `ItemEffect` subtypes and their field names (`stat`, `amount`, `skill`, `damageType`, `dice`, `text`) match between Models.kt, EquipmentEffects.kt, and every test. `recalcHpAfterEquip(oldChar, newChar)` signature is consistent between Task 7 Step 3 and Step 5.

--- a/docs/superpowers/specs/2026-04-24-equipment-effects-design.md
+++ b/docs/superpowers/specs/2026-04-24-equipment-effects-design.md
@@ -1,0 +1,162 @@
+# Equipment Effects Design
+
+**Date:** 2026-04-24
+**Branch:** envelope-repair-and-shop-removal (current)
+**Goal:** Make equipped items matter — mechanically (code owns hard numbers: AC, max HP, ability scores) and narratively (LLM sees a structured summary of every equipped effect and honors it in checks, combat narration, and outcomes).
+
+---
+
+## Current state
+
+- `Item` has `type`, `rarity`, `damage: String?`, `ac: Int?`, `equipped: Boolean`. No other effect data.
+- Armor AC is applied exactly once in `applyClassStart` (`game/Classes.kt:199-201`). Swapping armor mid-game does not recompute AC.
+- Character abilities are static `Abilities` scores with no layered modifiers.
+- The LLM prompt includes `"Equipped: ..."` as a plain comma-joined name list at `GameViewModel.kt:427` and `1180`. No effect data reaches the model.
+- `ItemSpec` (LLM-emitted loot) has only `name`, `desc`, `type`, `rarity`.
+
+## Requirements
+
+Support all of the following, with tests for each:
+
+1. Weapon damage drives combat outcomes (LLM-informed via prompt)
+2. AC / shield stack live
+3. Ability bonuses (+X STR, etc.)
+4. Skill / check bonuses (+X Stealth, etc.)
+5. Damage resistances / immunities
+6. Passive triggers / on-hit effects (flaming weapon, vorpal, cursed)
+7. Max HP modifiers (Amulet of Health)
+
+## Architecture
+
+### Data model — typed effect list
+
+Add to `data/Models.kt`:
+
+```kotlin
+@Serializable
+sealed interface ItemEffect {
+    @Serializable @SerialName("ability") data class AbilityBonus(val stat: String, val amount: Int) : ItemEffect
+    @Serializable @SerialName("skill")   data class SkillBonus(val skill: String, val amount: Int) : ItemEffect
+    @Serializable @SerialName("resist")  data class Resistance(val damageType: String) : ItemEffect
+    @Serializable @SerialName("immune")  data class Immunity(val damageType: String) : ItemEffect
+    @Serializable @SerialName("onhit")   data class OnHit(val dice: String, val damageType: String) : ItemEffect
+    @Serializable @SerialName("maxhp")   data class MaxHpBonus(val amount: Int) : ItemEffect
+    @Serializable @SerialName("trigger") data class PassiveTrigger(val text: String) : ItemEffect
+}
+```
+
+`Item` and `ItemSpec` both gain `val effects: List<ItemEffect> = emptyList()`. Default-empty means existing saves and existing LLM outputs load without migration.
+
+`stat` values: `STR`/`DEX`/`CON`/`INT`/`WIS`/`CHA`.
+`damageType` values: free-form lowercase strings (fire, cold, lightning, poison, physical, psychic, …). Code doesn't validate — the LLM authors them and also consumes them.
+`dice` values: D&D-style dice strings (`"1d4"`, `"2d6"`), optionally with a leading `+`.
+`PassiveTrigger.text` is free-form narrative instruction consumed only by the LLM.
+
+### Core — `EquipmentEffects` pure functions
+
+New file `app/src/main/kotlin/com/realmsoffate/game/game/EquipmentEffects.kt`. No Android deps. All pure, testable on JVM.
+
+```kotlin
+object EquipmentEffects {
+    fun activeEffects(ch: Character): List<ItemEffect>
+    fun effectiveAbilities(ch: Character): Abilities
+    fun effectiveAc(ch: Character): Int
+    fun effectiveMaxHp(ch: Character): Int
+    fun skillBonuses(ch: Character): Map<String, Int>
+    fun resistances(ch: Character): Set<String>
+    fun immunities(ch: Character): Set<String>
+    fun onHitRiders(ch: Character): List<ItemEffect.OnHit>
+    fun passiveTriggers(ch: Character): List<String>
+    fun promptSummary(ch: Character): String
+}
+```
+
+Rules:
+- `activeEffects` returns effects flat-mapped only from items with `equipped = true`.
+- `effectiveAbilities` takes `ch.abilities` and adds all `AbilityBonus` amounts per stat. Returns a new `Abilities` copy — original is untouched.
+- `effectiveAc` replaces the Classes.kt logic: if an equipped item has non-null `ac`, start there; otherwise 10 + DEX mod. Heavy armor (Chain Mail, Plate) ignores DEX. Shield (equipped, `type == "shield"`) adds +2. DEX for the calculation uses `effectiveAbilities(ch).dexMod` so a Cloak of Dex propagates.
+- `effectiveMaxHp` = current `ch.maxHp` + sum of `MaxHpBonus.amount` from equipped items **that are not already written through** (see equip handling below). In practice the authoritative `ch.maxHp` is updated on equip/unequip, so `effectiveMaxHp` and `ch.maxHp` agree outside that transient window and this helper is mainly a documentation seam for tests and UI code.
+- `skillBonuses` sums per skill name. Case-insensitive keys, canonical capitalization in output.
+- `resistances`/`immunities` are sets (duplicates collapse).
+- `onHitRiders` returns every `OnHit` from equipped items in declaration order.
+- `passiveTriggers` returns `text` values from every equipped `PassiveTrigger`.
+- `promptSummary` returns a human-readable block (see below). Empty string when nothing equipped has effects.
+
+### Equip/unequip recomputation
+
+In `GameViewModel.equipToggle` (`game/GameViewModel.kt:1645`), after the existing equip/displace logic, we **write through** the AC and maxHp deltas so `ch.ac` and `ch.maxHp` remain authoritative for UI:
+
+```kotlin
+// Delta approach: compute what changed between old and new equipped sets.
+val oldEquipped = ch.inventory.filter { it.equipped }
+val newEquipped = inv.filter { it.equipped }
+val deltaMaxHp = newEquipped.sumMaxHpBonus() - oldEquipped.sumMaxHpBonus()
+val newMaxHp = (ch.maxHp + deltaMaxHp).coerceAtLeast(1)
+val newHp = minOf(ch.hp, newMaxHp) // clamp down when max drops; do not auto-heal when max rises
+val newCh0 = ch.copy(inventory = inv, maxHp = newMaxHp, hp = newHp)
+val newAc = EquipmentEffects.effectiveAc(newCh0)
+_ui.value = s.copy(character = newCh0.copy(ac = newAc))
+```
+
+Rationale: `ch.maxHp` already carries level-up accumulations, so additive delta is the safe mutation. This preserves existing behavior for code that reads `ch.maxHp` directly (HP bar UI, save/load). For ability bonuses we do **not** write through — `ch.abilities` stays as the base score, and every site that does stat math reads `effectiveAbilities(ch)` instead. This avoids compounding interactions with level-up ASI / items that touch the same stat.
+
+### LLM integration
+
+**Prompt summary format** (emitted by `promptSummary`):
+
+```
+Equipped gear:
+- Flametongue Longsword (weapon, 1d8 slashing) — on hit: +1d6 fire
+- Plate Armor (AC 18)
+- Ring of Strength — +2 STR (applied)
+- Cloak of Stealth — +2 Stealth checks
+- Cursed Ring — passive: -1 to all rolls
+Resistances: fire, cold
+Immunities: poison
+```
+
+Lines per item show name, type, damage (weapons), AC (armor), then ability bonuses (noting "applied" because the LLM already sees the boosted score), skill bonuses, on-hit riders, passive triggers. Final two lines roll up resistances/immunities.
+
+**Prompt system-text additions** (in `data/prompts/`): tell the LLM:
+- Ability-bonus effects are already folded into the `Abilities` it sees in the prompt — do not re-apply them to checks.
+- Skill-bonus effects should be added to skill-check rolls.
+- Resistances halve incoming damage of that type; immunities negate it entirely.
+- On-hit riders add their damage to successful weapon attacks.
+- Passive triggers are narrative law — respect them as written.
+
+**`ItemSpec` effects** — LLM loot emission gains the same `effects` list. Turn-effects schema doc gets an example showing a fire-resist ring.
+
+**Two prompt sites to update:** `GameViewModel.kt:427` and `1180`. Both currently call `ch.inventory.filter { it.equipped }.joinToString(...) { it.name }`. Both become `EquipmentEffects.promptSummary(ch)`.
+
+**Effective abilities in prompts** — grep every site that serializes `ch.abilities` into a prompt; replace with `EquipmentEffects.effectiveAbilities(ch)` so the LLM's check math stays consistent.
+
+### UI
+
+- Inventory `SelectedItemCard` adds a small effects list below damage/AC (e.g., `"+2 STR"`, `"+2 Stealth"`, `"Fire Resist"`, `"On hit: +1d4 fire"`, passive-trigger text).
+- `BackpackCell` shows a compact indicator (a small chip or suffix) when an item carries effects, but doesn't enumerate them (not enough room).
+- Character sheet stat display: when a stat has an active ability bonus, show `STR 16 (+2) = 18`.
+
+### Testing
+
+JVM tests under `app/src/test/kotlin/com/realmsoffate/game/game/`:
+
+1. `EquipmentEffectsTest.kt` — each public function, covering both equipped and unequipped items, zero/one/many effects, heavy-armor DEX exclusion, multiple resistances collapse, etc.
+2. `EquipToggleEffectsTest.kt` — equipping a Ring of Strength (+2 STR) raises `effectiveAbilities().str`; unequipping restores base. AC changes live when armor swaps. Equipping Amulet of Health raises `effectiveMaxHp`; unequipping drops it; current hp clamps down if it was above the new max; current hp does not auto-heal when max rises.
+3. `ItemEffectSerializationTest.kt` — polymorphic round-trip for each sealed subtype; legacy `Item` JSON with no `effects` field deserializes to empty list.
+4. `PromptSummaryTest.kt` — `promptSummary(ch)` emits the expected text for a representative equipped set; empty state returns empty string.
+5. `ItemSpecEffectsParseTest.kt` — LLM-emitted `ItemSpec` JSON containing an `effects` array parses correctly; items-gained flow transfers effects into the player inventory.
+
+One regression test is added to the existing `AutoTagUnknownNpcsTest.kt` only if an effect-related change touches that file; otherwise the new tests live in their own files.
+
+### Migration
+
+- `effects: List<ItemEffect> = emptyList()` on both `Item` and `ItemSpec` — no save migration needed.
+- `Classes.kt` starting-inventory authoring is unchanged except to express existing AC/damage in the new schema as-is. We are wiring the system, not rebalancing classes.
+- `Classes.kt:199-201` is deleted in favor of `EquipmentEffects.effectiveAc(ch)` called at the end of `applyClassStart`.
+
+## Out of scope
+
+- Rebalancing class starting gear with new effects.
+- Authoring a curated magic-item table — LLM-emitted loot will populate effects going forward.
+- Cursed items that block unequip (nothing currently prevents unequip; the `PassiveTrigger` text is informational only).
+- Attunement limits.


### PR DESCRIPTION
## Summary

- **Equipment effects system** — new `ItemEffect` sealed interface + `EquipmentEffects` engine computing effective abilities, AC (with shield / heavy-armor DEX rule), maxHp, skill bonuses, resistances, immunities, onHit, and triggers. Wired into `equipToggle`, ability math, class start, and the LLM prompt (loot schema, narrator rules, `promptSummary` gear block).
- **Inventory UI** — dedicated shield slot, amulet + 2 ring row, clothes slot, slot-limit enforcement, uniform equipment/backpack tile heights, per-slot effect list on selection, capitalized empty labels and item names, routed consumable Use through the LLM with qty decrement.
- **Combat spell picker** — Spells action chip now opens a bottom-sheet spell list in-place instead of yanking the player to the Character pager.
- **NPC auto-tagger** — filter equipment-like names (`Iron Sword`, `Bone Shield`) and exact matches against inventory / spellbook out of the proper-noun scan.
- **Envelope parser / shop removal** — hardened envelope parsing and removed the shop/merchant system (handler, overlay, save path, tests).

## Test plan

- [ ] Equip/unequip gear and verify AC, HP, and ability score deltas apply correctly
- [ ] Heavy armor clamps DEX bonus to AC; shield stacks
- [ ] Confirm LLM prompt includes the equipped-gear block (check debug dump)
- [ ] Amulet + dual rings + shield all equip into their dedicated slots; slot limits reject extras
- [ ] Consumable Use decrements quantity and narrates via LLM
- [ ] In combat, Spells chip opens bottom sheet; tapping a spell routes through target prompt or self-cast
- [ ] Unavailable slot levels show "No slots" and don't dispatch
- [ ] Narration with "Bone Shield" / "Iron Sword" does not auto-tag as NPCs

🤖 Generated with [Claude Code](https://claude.com/claude-code)