### PR TITLE
Equipment effects, inventory slots, envelope hardening, shop removal

### DIFF
--- a/app/src/main/kotlin/com/realmsoffate/game/ui/game/GameOverlays.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/ui/game/GameOverlays.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.realmsoffate.game.BuildConfig
 import com.realmsoffate.game.data.Choice
 import com.realmsoffate.game.ui.theme.RealmsElevation
 import com.realmsoffate.game.ui.theme.RealmsSpacing
@@ -176,6 +177,14 @@ internal fun SettingsPanel(
                 }
             }
 
+            Spacer(Modifier.height(RealmsSpacing.l))
+            Text(
+                "Version ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Center
+            )
             Spacer(Modifier.navigationBarsPadding().height(RealmsSpacing.m))
         }
     }

--- a/app/src/main/kotlin/com/realmsoffate/game/ui/setup/CharacterCreationScreen.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/ui/setup/CharacterCreationScreen.kt
@@ -780,7 +780,7 @@ private fun GradientBeginButton(enabled: Boolean, onClick: () -> Unit, modifier:
                 Icon(Icons.Default.Check, null, Modifier.size(18.dp))
                 Spacer(Modifier.width(8.dp))
                 Text(
-                    "BEGIN THE TALE",
+                    "BEGIN",
                     style = MaterialTheme.typography.titleSmall.copy(letterSpacing = 2.sp),
                     fontWeight = FontWeight.Bold,
                     maxLines = 1

--- a/app/src/main/kotlin/com/realmsoffate/game/ui/theme/Type.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/ui/theme/Type.kt
@@ -3,6 +3,9 @@ package com.realmsoffate.game.ui.theme
 import androidx.compose.material3.Typography
 import androidx.compose.material3.Shapes
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.text.EmojiSupportMatch
+import androidx.compose.ui.text.PlatformParagraphStyle
+import androidx.compose.ui.text.PlatformTextStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
@@ -22,23 +25,33 @@ private val TitleSerif = CinzelFontFamily
 private val BodySans = FontFamily.Default
 private val NarrationSerif = CrimsonTextFontFamily
 
+// Force every emoji to go through EmojiCompat's bundled NotoColorEmoji font so
+// Samsung devices don't fall back to the OEM emoji set. EmojiCompat is inited
+// in RealmsApp; without EmojiSupportMatch.All, Compose only rewrites emojis the
+// system doesn't recognize — Samsung claims to support them all, so none get
+// rewritten by default.
+private val EmojiAllPlatformStyle = PlatformTextStyle(
+    spanStyle = null,
+    paragraphStyle = PlatformParagraphStyle(emojiSupportMatch = EmojiSupportMatch.All)
+)
+
 val RealmsTypography = Typography(
-    displayLarge = TextStyle(fontFamily = TitleSerif, fontWeight = FontWeight.Bold, fontSize = 44.sp, lineHeight = 48.sp, letterSpacing = 2.sp),
-    displayMedium = TextStyle(fontFamily = TitleSerif, fontWeight = FontWeight.Bold, fontSize = 34.sp, lineHeight = 40.sp, letterSpacing = 1.5.sp),
-    displaySmall = TextStyle(fontFamily = TitleSerif, fontWeight = FontWeight.Bold, fontSize = 26.sp, lineHeight = 32.sp, letterSpacing = 1.sp),
-    headlineLarge = TextStyle(fontFamily = TitleSerif, fontWeight = FontWeight.Bold, fontSize = 28.sp, lineHeight = 34.sp, letterSpacing = 1.sp),
-    headlineMedium = TextStyle(fontFamily = TitleSerif, fontWeight = FontWeight.Bold, fontSize = 22.sp, lineHeight = 28.sp, letterSpacing = 0.8.sp),
-    headlineSmall = TextStyle(fontFamily = TitleSerif, fontWeight = FontWeight.SemiBold, fontSize = 20.sp, lineHeight = 26.sp, letterSpacing = 0.5.sp),
-    titleLarge = TextStyle(fontFamily = TitleSerif, fontWeight = FontWeight.Bold, fontSize = 18.sp, lineHeight = 24.sp, letterSpacing = 0.3.sp),
-    titleMedium = TextStyle(fontFamily = TitleSerif, fontWeight = FontWeight.SemiBold, fontSize = 15.sp, lineHeight = 20.sp, letterSpacing = 0.3.sp),
-    titleSmall = TextStyle(fontFamily = TitleSerif, fontWeight = FontWeight.SemiBold, fontSize = 13.sp, lineHeight = 18.sp, letterSpacing = 0.4.sp),
-    bodyLarge = TextStyle(fontFamily = BodySans, fontWeight = FontWeight.Normal, fontSize = 15.sp, lineHeight = 22.sp, letterSpacing = 0.2.sp),
-    bodyMedium = TextStyle(fontFamily = BodySans, fontWeight = FontWeight.Normal, fontSize = 13.sp, lineHeight = 19.sp, letterSpacing = 0.2.sp),
-    bodySmall = TextStyle(fontFamily = BodySans, fontWeight = FontWeight.Normal, fontSize = 12.sp, lineHeight = 16.sp, letterSpacing = 0.2.sp),
+    displayLarge = TextStyle(fontFamily = TitleSerif, fontWeight = FontWeight.Bold, fontSize = 44.sp, lineHeight = 48.sp, letterSpacing = 2.sp, platformStyle = EmojiAllPlatformStyle),
+    displayMedium = TextStyle(fontFamily = TitleSerif, fontWeight = FontWeight.Bold, fontSize = 34.sp, lineHeight = 40.sp, letterSpacing = 1.5.sp, platformStyle = EmojiAllPlatformStyle),
+    displaySmall = TextStyle(fontFamily = TitleSerif, fontWeight = FontWeight.Bold, fontSize = 26.sp, lineHeight = 32.sp, letterSpacing = 1.sp, platformStyle = EmojiAllPlatformStyle),
+    headlineLarge = TextStyle(fontFamily = TitleSerif, fontWeight = FontWeight.Bold, fontSize = 28.sp, lineHeight = 34.sp, letterSpacing = 1.sp, platformStyle = EmojiAllPlatformStyle),
+    headlineMedium = TextStyle(fontFamily = TitleSerif, fontWeight = FontWeight.Bold, fontSize = 22.sp, lineHeight = 28.sp, letterSpacing = 0.8.sp, platformStyle = EmojiAllPlatformStyle),
+    headlineSmall = TextStyle(fontFamily = TitleSerif, fontWeight = FontWeight.SemiBold, fontSize = 20.sp, lineHeight = 26.sp, letterSpacing = 0.5.sp, platformStyle = EmojiAllPlatformStyle),
+    titleLarge = TextStyle(fontFamily = TitleSerif, fontWeight = FontWeight.Bold, fontSize = 18.sp, lineHeight = 24.sp, letterSpacing = 0.3.sp, platformStyle = EmojiAllPlatformStyle),
+    titleMedium = TextStyle(fontFamily = TitleSerif, fontWeight = FontWeight.SemiBold, fontSize = 15.sp, lineHeight = 20.sp, letterSpacing = 0.3.sp, platformStyle = EmojiAllPlatformStyle),
+    titleSmall = TextStyle(fontFamily = TitleSerif, fontWeight = FontWeight.SemiBold, fontSize = 13.sp, lineHeight = 18.sp, letterSpacing = 0.4.sp, platformStyle = EmojiAllPlatformStyle),
+    bodyLarge = TextStyle(fontFamily = BodySans, fontWeight = FontWeight.Normal, fontSize = 15.sp, lineHeight = 22.sp, letterSpacing = 0.2.sp, platformStyle = EmojiAllPlatformStyle),
+    bodyMedium = TextStyle(fontFamily = BodySans, fontWeight = FontWeight.Normal, fontSize = 13.sp, lineHeight = 19.sp, letterSpacing = 0.2.sp, platformStyle = EmojiAllPlatformStyle),
+    bodySmall = TextStyle(fontFamily = BodySans, fontWeight = FontWeight.Normal, fontSize = 12.sp, lineHeight = 16.sp, letterSpacing = 0.2.sp, platformStyle = EmojiAllPlatformStyle),
     // Label styles used heavily for section headers; expanded tracking mimics Cinzel small-caps.
-    labelLarge = TextStyle(fontFamily = TitleSerif, fontWeight = FontWeight.Bold, fontSize = 12.sp, lineHeight = 16.sp, letterSpacing = 2.sp),
-    labelMedium = TextStyle(fontFamily = BodySans, fontWeight = FontWeight.Medium, fontSize = 11.sp, lineHeight = 14.sp, letterSpacing = 0.5.sp),
-    labelSmall = TextStyle(fontFamily = BodySans, fontWeight = FontWeight.Medium, fontSize = 10.sp, lineHeight = 14.sp, letterSpacing = 0.5.sp)
+    labelLarge = TextStyle(fontFamily = TitleSerif, fontWeight = FontWeight.Bold, fontSize = 12.sp, lineHeight = 16.sp, letterSpacing = 2.sp, platformStyle = EmojiAllPlatformStyle),
+    labelMedium = TextStyle(fontFamily = BodySans, fontWeight = FontWeight.Medium, fontSize = 11.sp, lineHeight = 14.sp, letterSpacing = 0.5.sp, platformStyle = EmojiAllPlatformStyle),
+    labelSmall = TextStyle(fontFamily = BodySans, fontWeight = FontWeight.Medium, fontSize = 10.sp, lineHeight = 14.sp, letterSpacing = 0.5.sp, platformStyle = EmojiAllPlatformStyle)
 )
 
 val RealmsShapes = Shapes(
@@ -55,7 +68,8 @@ val NarrationBodyStyle = TextStyle(
     fontWeight = FontWeight.Normal,
     fontSize = 16.sp,
     lineHeight = 25.sp,
-    letterSpacing = 0.2.sp
+    letterSpacing = 0.2.sp,
+    platformStyle = EmojiAllPlatformStyle
 )
 
 // Italic body for narration's *action* lines; used in the Markdown renderer.
@@ -65,5 +79,6 @@ val NarrationItalic = TextStyle(
     fontWeight = FontWeight.Normal,
     fontSize = 16.sp,
     lineHeight = 25.sp,
-    letterSpacing = 0.2.sp
+    letterSpacing = 0.2.sp,
+    platformStyle = EmojiAllPlatformStyle
 )

--- a/app/src/main/res/drawable/ic_splash_sword.xml
+++ b/app/src/main/res/drawable/ic_splash_sword.xml
@@ -1,0 +1,52 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="192"
+    android:viewportHeight="192">
+
+    <!--
+      Splash-screen variant of the launcher sword. Identical geometry, but the
+      stroke color tracks @color/splash_icon_tint so it stays visible against
+      the themed splash background (light / dark / Material You dynamic).
+    -->
+
+    <group
+        android:pivotX="96"
+        android:pivotY="96"
+        android:rotation="45">
+
+        <!-- Blade -->
+        <path
+            android:fillColor="#00000000"
+            android:strokeColor="@color/splash_icon_tint"
+            android:strokeWidth="6"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round"
+            android:pathData="M96,51 L102,66 L102,108 L96,113 L90,108 L90,66 Z" />
+
+        <!-- Cross-guard -->
+        <path
+            android:fillColor="#00000000"
+            android:strokeColor="@color/splash_icon_tint"
+            android:strokeWidth="6"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round"
+            android:pathData="M72,114 L120,114" />
+
+        <!-- Grip -->
+        <path
+            android:fillColor="#00000000"
+            android:strokeColor="@color/splash_icon_tint"
+            android:strokeWidth="6"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round"
+            android:pathData="M96,114 L96,134" />
+
+        <!-- Pommel -->
+        <path
+            android:fillColor="#00000000"
+            android:strokeColor="@color/splash_icon_tint"
+            android:strokeWidth="6"
+            android:pathData="M96,141 m-6,0 a6,6 0 1,0 12,0 a6,6 0 1,0 -12,0" />
+    </group>
+</vector>

--- a/app/src/main/res/values-night-v31/colors.xml
+++ b/app/src/main/res/values-night-v31/colors.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!--
+      Android 12+ Material You, dark mode. Mirrors values-v31/ but with
+      neutral-900 for the surface and accent1_200 for the icon tint.
+    -->
+    <color name="splash_bg">@android:color/system_neutral1_900</color>
+    <color name="splash_icon_tint">@android:color/system_accent1_200</color>
+    <color name="window_bg">@android:color/system_neutral1_900</color>
+</resources>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Dark-mode counterparts of splash colors in values/colors.xml. -->
+    <color name="splash_bg">#121015</color>
+    <color name="splash_icon_tint">#E2B84A</color>
+    <color name="window_bg">#121015</color>
+</resources>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="Theme.RealmsOfFate" parent="Theme.SplashScreen">
-        <item name="windowSplashScreenBackground">@color/bg_dark</item>
-        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>
+        <item name="windowSplashScreenBackground">@color/splash_bg</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_splash_sword</item>
         <item name="postSplashScreenTheme">@style/Theme.RealmsOfFate.Main</item>
-        <item name="android:windowBackground">@color/bg_dark</item>
+        <item name="android:windowBackground">@color/window_bg</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:enforceStatusBarContrast">false</item>
@@ -12,7 +12,7 @@
     </style>
 
     <style name="Theme.RealmsOfFate.Main" parent="android:Theme.Material.NoActionBar">
-        <item name="android:windowBackground">@color/bg_dark</item>
+        <item name="android:windowBackground">@color/window_bg</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:windowLightStatusBar">false</item>

--- a/app/src/main/res/values-v31/colors.xml
+++ b/app/src/main/res/values-v31/colors.xml
@@ -7,4 +7,12 @@
       tint) gives a visibly themed background instead of a near-white neutral.
     -->
     <color name="ic_launcher_background">@android:color/system_accent1_100</color>
+
+    <!--
+      Splash + window also pull from dynamic tokens so the pre-Compose frames
+      match the Compose theme that will take over. Light-mode variants.
+    -->
+    <color name="splash_bg">@android:color/system_neutral1_50</color>
+    <color name="splash_icon_tint">@android:color/system_accent1_600</color>
+    <color name="window_bg">@android:color/system_neutral1_50</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -4,4 +4,13 @@
     <color name="purple">#8B6CC7</color>
     <color name="bg_dark">#1D1B20</color>
     <color name="ic_launcher_background">#F4F1F6</color>
+
+    <!--
+      Splash + pre-Compose window colors track the Compose M3 palette.
+      Values here = light mode / FallbackLight. values-night/ overrides for dark.
+      values-v31/ + values-night-v31/ swap in Material You dynamic tokens.
+    -->
+    <color name="splash_bg">#FDFAF2</color>
+    <color name="splash_icon_tint">#B8891A</color>
+    <color name="window_bg">#FDFAF2</color>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,19 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Launch theme used by the activity until Compose takes over. -->
+    <!--
+      Launch theme shown before Compose mounts. Colors come from the M3
+      palette (values/ + values-night/ for day/night, values-v31/ +
+      values-night-v31/ for Material You dynamic tokens on Android 12+).
+    -->
     <style name="Theme.RealmsOfFate" parent="Theme.SplashScreen">
-        <item name="windowSplashScreenBackground">@color/bg_dark</item>
-        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>
+        <item name="windowSplashScreenBackground">@color/splash_bg</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_splash_sword</item>
         <item name="postSplashScreenTheme">@style/Theme.RealmsOfFate.Main</item>
-        <item name="android:windowBackground">@color/bg_dark</item>
+        <item name="android:windowBackground">@color/window_bg</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:enforceStatusBarContrast">false</item>
         <item name="android:enforceNavigationBarContrast">false</item>
     </style>
 
+    <!--
+      Post-splash window theme. Compose drives all colors via MaterialTheme;
+      this only needs to match window chrome so the first frame doesn't flash.
+    -->
     <style name="Theme.RealmsOfFate.Main" parent="android:Theme.Material.NoActionBar">
-        <item name="android:windowBackground">@color/bg_dark</item>
+        <item name="android:windowBackground">@color/window_bg</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:windowLightStatusBar">false</item>


### PR DESCRIPTION
## Summary
- Hardened envelope parsing and ripped out the shop system
- Full equipment-effects system: `ItemEffect` sealed interface, `EquipmentEffects` aggregator (AC, max HP, skills, resistances, immunities, on-hit, triggers, ability overrides), LLM prompt integration, and narrative equip toggles
- Inventory UX overhaul: dedicated shield slot, amulet + clothes + dual-ring slots, slot-limit enforcement, uniform cell sizing, effect list on selected item
- Prompt/loot schema teaches the narrator about equipped-gear effects
- Combat: bottom-sheet spell picker for the Spells button
- Misc polish: M3 palette for splash (day/night + dynamic), NPC auto-tagger filters equipment/inventory names, inventory label/name capitalization, EmojiCompat forced across typography, app version in settings footer, shorter "BEGIN" button

## Test plan
- [ ] Equip/unequip each slot type (weapon, shield, armor, amulet, clothes, rings) and verify AC / HP / ability / skill deltas apply
- [ ] Consumables decrement on Use and route through the LLM
- [ ] Envelope parser survives malformed LLM output (no crashes, no shop residue)
- [ ] Loot items with `effects` parse and render the effect list in item detail
- [ ] Narrator prompt reflects equipped-gear `promptSummary`
- [ ] Combat Spells button opens the new bottom-sheet picker
- [ ] Settings footer shows version, splash tracks M3 dynamic color, BEGIN button fits, emoji render via NotoColorEmoji on Samsung

🤖 Generated with [Claude Code](https://claude.com/claude-code)