### PR TITLE
Phase 5: fully realize #25 + #27 — freq_penalty, time-based summary, contradictions, key decisions, voice restoration

### DIFF
--- a/app/src/main/kotlin/com/realmsoffate/game/data/AiRepository.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/data/AiRepository.kt
@@ -24,7 +24,10 @@ import java.util.concurrent.TimeUnit
  *
  * DeepSeek is tuned specifically here:
  *   - temperature 1.0, top_p 0.95 (DeepSeek creative-writing sweet spot)
- *   - frequency_penalty 0.3, presence_penalty 0.1 (cuts repetition)
+ *   - frequency_penalty 0.1, presence_penalty 0.1 (light repetition pressure;
+ *     dropped from 0.3 because the BG3-narrator voice depends on recurring
+ *     vocabulary like "Between you and me…" / "I've seen this before". Higher
+ *     penalty was flattening the very fingerprints we want to keep.)
  *   - max_tokens 1800
  *   - DS_PREFIX + SYS as a stable system message — DeepSeek auto-caches
  *     identical prefixes so this pays off across turns.
@@ -44,6 +47,11 @@ class AiRepository(
     companion object {
         /** Default history budget in tokens — leaves headroom for system + scene summaries + per-turn context. */
         const val HISTORY_TOKEN_BUDGET: Int = 8000
+
+        /** Light repetition pressure. Was 0.3 (DeepSeek's documented creative-writing
+         *  default), but the BG3-narrator voice depends on recurring stylistic
+         *  fingerprints — lowered to 0.1 so those survive a long session. */
+        const val FREQUENCY_PENALTY: Double = 0.1
 
         /** Shared lenient parser — reused by [parseBalance] and [parseSummaryResponse] so we
          *  don't allocate a configuration object on every parse. */
@@ -152,7 +160,7 @@ class AiRepository(
             put("max_tokens", 1800)
             put("temperature", 1.0)
             put("top_p", 0.95)
-            put("frequency_penalty", 0.3)
+            put("frequency_penalty", FREQUENCY_PENALTY)
             put("presence_penalty", 0.1)
             put("messages", messages)
             put("response_format", buildJsonObject { put("type", "json_object") })

--- a/app/src/main/kotlin/com/realmsoffate/game/data/Prompts.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/data/Prompts.kt
@@ -90,6 +90,12 @@ GOOD: Player says "I have a brother named Cael." → Cael exists. Weave him into
 BAD: Player writes 'I tell him: "I serve no king."' → You have the duke respond as if they pledged loyalty.
 GOOD: Player writes 'I tell him: "I serve no king."' → Those exact words leave their mouth. The duke reacts to THAT.
 
+More YES-AND examples — these are the spirit, not edge cases:
+- "I cast Fireball at the king." → THEY CAST IT. Roll consequences. Guards explode into action.
+- "I leap from the tower." → THEY LEAP. The fall is YOUR problem to narrate.
+- "There's a hidden compartment behind the bookshelf." → THERE IS. Even if you hadn't planned it. Reward the player's instinct.
+- "I drink the strange potion." → THEY DRINK IT. Find an outcome that's interesting, not safe.
+
 YES-AND, NEVER NO-BUT:
 - Impossible action? Set a brutal DC (20+, sometimes nat-20-only). Roll it. The ATTEMPT is always canon.
 - Player invents lore mid-turn? Treat it as TRUE unless it contradicts established facts.
@@ -97,11 +103,13 @@ YES-AND, NEVER NO-BUT:
 - The only "no" is a die roll. Bad ideas have COSTS, not refusals.
 
 LENGTH & PROSE RULES:
-- 200-400 words of narration + tags + choices per turn. 4-8 rich paragraphs, 2-5 sentences each.
-- Layer sensory details — sounds, smells, textures, light. TWO or THREE vivid details per scene.
-- NPC dialogue: 1-3 sentences. Verbal tics, dialect, trailing off. Personality in every line.
-- Combat: visceral and cinematic. The physics of the blow, the sound, the aftermath.
-- Environmental storytelling: a half-eaten meal, a child's toy near a bloodstain, footprints that stop at a wall.
+- 200-400 words of narration + tags + choices per turn. 4-8 RICH paragraphs, 2-5 sentences each.
+- Each paragraph: layer sensory details — sounds, smells, textures, light. TWO or THREE vivid details per scene. Make the world BREATHE.
+- OPENING PARAGRAPHS paint the scene: what the player sees, hears, feels. Don't just place them — surround them.
+- Concrete sensory example: "Blood on the altar, still warm. The incense has gone sour — a cloying sweetness that clings to the back of your throat. Something scratches behind the reliquary." That's the bar.
+- NPC dialogue: 1-3 sentences. Verbal tics, dialect, interruptions, trailing off. Personality in every line.
+- Combat: VISCERAL and CINEMATIC. The physics of the blow, the sound, the aftermath. One killer image.
+- Environmental storytelling: scattered items tell stories. A half-eaten meal. A child's toy near a bloodstain. Footprints that stop at a wall.
 
 TONE EXAMPLES (study these — this is your VOICE):
 SCENE-SETTING:

--- a/app/src/main/kotlin/com/realmsoffate/game/data/Prompts.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/data/Prompts.kt
@@ -727,3 +727,26 @@ fun renderRecentStoryBlock(narrations: List<String>): String {
     val joined = recent.joinToString("\n---\n") { it.take(600) }
     return "\n\nRECENT STORY (continue from here, do not reset or contradict):\n$joined"
 }
+
+/**
+ * Renders the RECENT CONTRADICTIONS user-prompt block from the
+ * ContradictionQueue snapshot.
+ *
+ * The queue records every time an arc summary mentioned a dead/cursed/doomed
+ * NPC without past-tense cues — i.e., the model hallucinated those NPCs as
+ * still active. Until now the queue was observe-only; surfacing the last 5
+ * entries in the user prompt forces the model to acknowledge and stop
+ * repeating each specific mistake.
+ *
+ * Each entry is already self-contained ("'Lord Marcus' marked dead but
+ * referenced as active in: ...") so we feed them in verbatim, just
+ * reformatted as a list. Returns "" for an empty queue.
+ */
+fun renderRecentContradictionsBlock(entries: List<String>): String {
+    val recent = entries.takeLast(5)
+    if (recent.isEmpty()) return ""
+    return buildString {
+        append("\n\nRECENT CONTRADICTIONS (prior hallucinations — DO NOT REPEAT these mistakes):\n")
+        recent.forEach { e -> append("- ").append(e).append('\n') }
+    }
+}

--- a/app/src/main/kotlin/com/realmsoffate/game/data/Prompts.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/data/Prompts.kt
@@ -750,3 +750,28 @@ fun renderRecentContradictionsBlock(entries: List<String>): String {
         recent.forEach { e -> append("- ").append(e).append('\n') }
     }
 }
+
+/**
+ * Renders the KEY DECISIONS user-prompt block from [WorldLore.history].
+ *
+ * worldLore.history accumulates per-turn `lore_entries` from the LLM —
+ * player kills, discoveries, secrets learned, faction shifts, quest
+ * milestones, anything the model judged was a lasting consequence. Each
+ * entry lands as `HistoryEntry(era="recent", year=turnNumber, text=…)`.
+ * Pre-existing primordial/ancient/medieval entries from world-gen also live
+ * in the same list with non-"recent" era tags.
+ *
+ * This block surfaces the last 8 player-driven entries chronologically,
+ * pinned independently of the keyword-retrieval system, so long-running
+ * consequences (a king dethroned 30 turns ago, a faction destroyed 50 turns
+ * ago) stay in the model's working set even when the current action shares
+ * no keywords with them. Returns "" when no recent entries exist.
+ */
+fun renderKeyDecisionsBlock(history: List<HistoryEntry>): String {
+    val recent = history.filter { it.era == "recent" }.takeLast(8)
+    if (recent.isEmpty()) return ""
+    return buildString {
+        append("\n\nKEY DECISIONS (lasting consequences of the player's actions — reference these whenever relevant):\n")
+        recent.forEach { e -> append("- ").append(e.text).append('\n') }
+    }
+}

--- a/app/src/main/kotlin/com/realmsoffate/game/game/GameViewModel.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/game/GameViewModel.kt
@@ -1102,7 +1102,10 @@ class GameViewModel(
                 locationName = finalState.worldMap?.locations?.getOrNull(finalState.currentLoc)?.name ?: "",
                 inCombat = finalState.combat != null
             )
-            val boundary = SceneBoundaryDetector.detect(preSnapshot, postSnapshot)
+            val turnsSinceLastSummary = (turnsBeforeResponse - priorSummaryEndTurn).coerceAtLeast(0)
+            val boundary = SceneBoundaryDetector.detectWithFallback(
+                preSnapshot, postSnapshot, turnsSinceLastSummary
+            )
             if (boundary != null) {
                 val apiKey = _apiKey.value
                 val sceneName = preSnapshot.sceneTag.ifBlank { "default" }
@@ -1110,7 +1113,7 @@ class GameViewModel(
                 // Slice the history that belongs to the completed scene: from after
                 // the previous summary's end turn through this turn. Each turn is
                 // roughly 2 messages (user + assistant), so window by turn count.
-                val turnsCovered = (turnsBeforeResponse - priorSummaryEndTurn).coerceAtLeast(1)
+                val turnsCovered = turnsSinceLastSummary.coerceAtLeast(1)
                 val approxMessages = (turnsCovered * 2).coerceAtMost(finalState.history.size)
                 val sceneHistory = finalState.history.takeLast(approxMessages + 2) // +2 = current user+assistant
                 val turnStart = priorSummaryEndTurn + 1

--- a/app/src/main/kotlin/com/realmsoffate/game/game/GameViewModel.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/game/GameViewModel.kt
@@ -22,6 +22,7 @@ import com.realmsoffate.game.data.ParsedReply
 import com.realmsoffate.game.data.PlayerPos
 import com.realmsoffate.game.data.PreferencesStore
 import com.realmsoffate.game.data.Prompts
+import com.realmsoffate.game.data.renderRecentContradictionsBlock
 import com.realmsoffate.game.data.renderRecentPlayerChoicesBlock
 import com.realmsoffate.game.data.renderRecentStoryBlock
 import com.realmsoffate.game.data.Quest
@@ -1308,6 +1309,7 @@ class GameViewModel(
                 .filter { it.role == "user" }
                 .map { it.content }
             append(renderRecentPlayerChoicesBlock(recentPlayerActions))
+            append(renderRecentContradictionsBlock(ContradictionQueue.snapshot()))
             // CANONICAL FACTS block — ground-truth entities pinned by scene relevance
             // plus keyword matches from repo + in-memory state.
             val canonical = buildCanonicalFacts(s, entityHits, tokens)

--- a/app/src/main/kotlin/com/realmsoffate/game/game/GameViewModel.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/game/GameViewModel.kt
@@ -22,6 +22,7 @@ import com.realmsoffate.game.data.ParsedReply
 import com.realmsoffate.game.data.PlayerPos
 import com.realmsoffate.game.data.PreferencesStore
 import com.realmsoffate.game.data.Prompts
+import com.realmsoffate.game.data.renderKeyDecisionsBlock
 import com.realmsoffate.game.data.renderRecentContradictionsBlock
 import com.realmsoffate.game.data.renderRecentPlayerChoicesBlock
 import com.realmsoffate.game.data.renderRecentStoryBlock
@@ -1309,6 +1310,7 @@ class GameViewModel(
                 .filter { it.role == "user" }
                 .map { it.content }
             append(renderRecentPlayerChoicesBlock(recentPlayerActions))
+            append(renderKeyDecisionsBlock(s.worldLore?.history.orEmpty()))
             append(renderRecentContradictionsBlock(ContradictionQueue.snapshot()))
             // CANONICAL FACTS block — ground-truth entities pinned by scene relevance
             // plus keyword matches from repo + in-memory state.

--- a/app/src/main/kotlin/com/realmsoffate/game/game/reducers/SceneBoundaryDetector.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/game/reducers/SceneBoundaryDetector.kt
@@ -14,8 +14,17 @@ object SceneBoundaryDetector {
         LOCATION_CHANGED,
         SCENE_TAG_CHANGED,
         COMBAT_STARTED,
-        COMBAT_ENDED
+        COMBAT_ENDED,
+        TURN_LIMIT_REACHED,
     }
+
+    /**
+     * Force a scene summary if no topology boundary has fired in this many
+     * turns. Without this fallback, a long single-scene exchange (extended
+     * combat, drawn-out social scene) silently loses oldest history past the
+     * 8000-token chat-history cap because no summary ever fires to compress it.
+     */
+    const val MAX_TURNS_WITHOUT_SUMMARY: Int = 8
 
     data class Snapshot(
         val sceneTag: String,
@@ -34,5 +43,16 @@ object SceneBoundaryDetector {
             return Reason.SCENE_TAG_CHANGED
         }
         return null
+    }
+
+    /**
+     * Same as [detect] but also fires [Reason.TURN_LIMIT_REACHED] when the
+     * caller reports [turnsSinceLastSummary] >= [MAX_TURNS_WITHOUT_SUMMARY] and
+     * no topology boundary triggered. Topology boundaries take precedence —
+     * the time-based fallback only fires when nothing else has.
+     */
+    fun detectWithFallback(prev: Snapshot, cur: Snapshot, turnsSinceLastSummary: Int): Reason? {
+        return detect(prev, cur)
+            ?: if (turnsSinceLastSummary >= MAX_TURNS_WITHOUT_SUMMARY) Reason.TURN_LIMIT_REACHED else null
     }
 }

--- a/app/src/test/kotlin/com/realmsoffate/game/data/PromptUserBlocksTest.kt
+++ b/app/src/test/kotlin/com/realmsoffate/game/data/PromptUserBlocksTest.kt
@@ -76,4 +76,31 @@ class PromptUserBlocksTest {
         assertTrue("entry_3 should appear", out.contains("entry_3"))
         assertTrue("entry_7 should appear", out.contains("entry_7"))
     }
+
+    @Test
+    fun `key decisions block returns empty for empty history`() {
+        assertEquals("", renderKeyDecisionsBlock(emptyList()))
+    }
+
+    @Test
+    fun `key decisions block filters to recent era and keeps last 8`() {
+        val seedLore = listOf(
+            HistoryEntry(era = "primordial", year = -2000, text = "PRIMORDIAL_X"),
+            HistoryEntry(era = "ancient", year = -800, text = "ANCIENT_X"),
+            HistoryEntry(era = "medieval", year = -400, text = "MEDIEVAL_X"),
+        )
+        val playerEntries = (1..10).map {
+            HistoryEntry(era = "recent", year = it, text = "decision_$it")
+        }
+        val out = renderKeyDecisionsBlock(seedLore + playerEntries)
+        assertTrue(out.contains("KEY DECISIONS"))
+        // Pre-existing era entries are filtered out — only player-driven decisions surface.
+        assertTrue("primordial seed should be filtered", !out.contains("PRIMORDIAL_X"))
+        assertTrue("ancient seed should be filtered", !out.contains("ANCIENT_X"))
+        assertTrue("medieval seed should be filtered", !out.contains("MEDIEVAL_X"))
+        // Last 8 of decision_1..decision_10 = decision_3..decision_10
+        assertTrue("decision_2 should be dropped (cap is 8)", !out.contains("decision_2"))
+        assertTrue("decision_3 should appear", out.contains("decision_3"))
+        assertTrue("decision_10 should appear", out.contains("decision_10"))
+    }
 }

--- a/app/src/test/kotlin/com/realmsoffate/game/data/PromptUserBlocksTest.kt
+++ b/app/src/test/kotlin/com/realmsoffate/game/data/PromptUserBlocksTest.kt
@@ -59,4 +59,21 @@ class PromptUserBlocksTest {
         val bRun = "b".repeat(599)
         assertTrue("m2 should be truncated to 600 chars (599 b's max)", !out.contains(bRun))
     }
+
+    @Test
+    fun `recent contradictions block returns empty for empty queue`() {
+        assertEquals("", renderRecentContradictionsBlock(emptyList()))
+    }
+
+    @Test
+    fun `recent contradictions block surfaces last 5 entries with do-not-repeat header`() {
+        val entries = (1..7).map { "entry_$it" }
+        val out = renderRecentContradictionsBlock(entries)
+        assertTrue(out.contains("RECENT CONTRADICTIONS"))
+        assertTrue(out.contains("DO NOT REPEAT"))
+        // Last 5 kept: entry_3..entry_7
+        assertTrue("entry_2 should be dropped", !out.contains("entry_2"))
+        assertTrue("entry_3 should appear", out.contains("entry_3"))
+        assertTrue("entry_7 should appear", out.contains("entry_7"))
+    }
 }

--- a/app/src/test/kotlin/com/realmsoffate/game/game/reducers/SceneBoundaryDetectorTest.kt
+++ b/app/src/test/kotlin/com/realmsoffate/game/game/reducers/SceneBoundaryDetectorTest.kt
@@ -80,4 +80,32 @@ class SceneBoundaryDetectorTest {
             SceneBoundaryDetector.detect(prev, cur)
         )
     }
+
+    @Test
+    fun `fallback fires turn-limit reason when no topology boundary and limit reached`() {
+        val s = snap()
+        assertEquals(
+            SceneBoundaryDetector.Reason.TURN_LIMIT_REACHED,
+            SceneBoundaryDetector.detectWithFallback(s, s, SceneBoundaryDetector.MAX_TURNS_WITHOUT_SUMMARY)
+        )
+    }
+
+    @Test
+    fun `fallback returns null when no topology boundary and limit not yet reached`() {
+        val s = snap()
+        assertNull(
+            SceneBoundaryDetector.detectWithFallback(s, s, SceneBoundaryDetector.MAX_TURNS_WITHOUT_SUMMARY - 1)
+        )
+    }
+
+    @Test
+    fun `topology boundary takes precedence over turn-limit fallback`() {
+        val prev = snap(location = "Ashford")
+        val cur = snap(location = "Greymoor")
+        // Turn limit reached AND a real boundary fired — must report the topology reason.
+        assertEquals(
+            SceneBoundaryDetector.Reason.LOCATION_CHANGED,
+            SceneBoundaryDetector.detectWithFallback(prev, cur, SceneBoundaryDetector.MAX_TURNS_WITHOUT_SUMMARY * 2)
+        )
+    }
 }


### PR DESCRIPTION
Stacked on #33. Closes the deferred work that Phase 4 explicitly carved out, fully resolving #25 and #27.

## Closes

- Closes #25
- Closes #27

## Changes

### #25 — prose quality

- **`frequency_penalty` 0.3 → 0.1** (commit `bbef341`). DeepSeek's docs cite 0.3 as the default for creative writing, but our specific need is the BG3-narrator voice fingerprint — which depends on recurring stylistic vocabulary the higher penalty was actively flattening. Promoted to a named `FREQUENCY_PENALTY` constant.
- **`Prompts.SYS` voice restoration** (commit `5b10fdb`). Commit f2baef8 traded ~22% of SYS words from voice exemplars to BAD/GOOD pairs. Most of the loss was old `[TAG]` syntax killed by the envelope migration anyway, but two sections lost real voice anchor:
  - `PLAYER AGENCY` — re-added 4 concrete examples ("I cast Fireball at the king", "I leap from the tower", etc.) so the model has unambiguous spirit, not just category coverage.
  - `LENGTH & PROSE RULES` — re-added the "Make the world BREATHE" opening-paragraphs framing, the sensory exemplar ("Blood on the altar, still warm…"), and the "scattered items tell stories" line.

### #27 — past actions

- **Time-based scene-summary fallback** (commit `8f4988c`). `SceneBoundaryDetector` previously only fired on location/combat/scene-tag transitions, so a long single-scene exchange silently lost oldest history past the 8000-token cap. New `Reason.TURN_LIMIT_REACHED` + `detectWithFallback(prev, cur, turnsSinceLastSummary)` forces a summary every 8 turns regardless of topology. Tests added.
- **`RECENT CONTRADICTIONS` block** (commit `51d0c46`). `ContradictionQueue.checkArc` has been recording dead-NPC-speaks hallucinations into a 200-entry queue since arc summaries shipped, but the queue was observe-only — never fed back. Now the last 5 detections surface in the user prompt with a "DO NOT REPEAT" framing so the model self-corrects.
- **`KEY DECISIONS` block** (commit `83ada85`). `worldLore.history` accumulates per-turn `lore_entries` (player kills, discoveries, faction shifts, quest milestones — see `WorldReducer:95-105`). Until now those entries surfaced in the prompt only when the keyword-matched arc-summary retrieval happened to catch them — long-running consequences with no shared keywords silently dropped. New `renderKeyDecisionsBlock` filters to `era=recent` and pins the last 8 entries chronologically, independent of retrieval.

## Test plan

- [x] `gradle :app:compileDebugKotlin` — BUILD SUCCESSFUL
- [x] `gradle :app:testDebugUnitTest` — all unit tests pass (3 new `SceneBoundaryDetectorTest` cases + 4 new `PromptUserBlocksTest` cases)
- [ ] Eyeball: 10+ turns of fresh gameplay — does the narrator voice sound richer? Do turns 8+ reference earlier player decisions/NPCs even after a scene change? Do dead NPCs stay dead in arc-rolled-up sessions?

## Stacking note

Branched off `phase4-winners` (PR #33). If #33 merges first, this rebases cleanly onto main. If reviewed in stacked order, the Phase 4 commits (instrumentation + Spike A/C/D) appear first; Phase 5 commits start at `bbef341`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)