### PR TITLE
feat(phase6): JSON content extraction M5b — WorldEvents + LoreGen history

### DIFF
--- a/app/src/main/assets/content/schema-version.json
+++ b/app/src/main/assets/content/schema-version.json
@@ -1,3 +1,3 @@
 {
-  "version": 4
+  "version": 5
 }

--- a/app/src/main/assets/content/world/historical-events.json
+++ b/app/src/main/assets/content/world/historical-events.json
@@ -1,0 +1,56 @@
+{
+  "primordial": [
+    "The gods shaped the land around **{loc}**. The earth still hums with their residual power.",
+    "A primordial titan fell near **{loc}**, its bones forming the bedrock. Its blood became the rivers.",
+    "The first elves emerged from the Feywild near **{loc}**, weeping at the beauty of the mortal sky.",
+    "Dragons claimed dominion over the region around **{loc}**. Their rule would last centuries.",
+    "The Weave of magic was woven across **{loc}** by unknown hands. Ley lines converge here still.",
+    "An ancient tree of immense power took root near **{loc}**. Druids would later name it the Worldheart."
+  ],
+  "ancient": [
+    "The **{f}** was founded by {n} after a divine vision at **{loc}**. Its tenets still shape the region.",
+    "A dwarven kingdom was carved beneath **{loc}**. Its forges burned for a century before falling silent.",
+    "{n} united the warring tribes near **{loc}** under the banner of the **{f}**, forging the first alliance.",
+    "The **Great Library of {loc}** was built, housing knowledge from across the realm. The **{f}** served as its guardians.",
+    "An elven city rose near **{loc}**, its towers touching the clouds. It would stand for five hundred years.",
+    "{n} discovered the first deposits of mythril beneath **{loc}**, sparking a rush that transformed the region.",
+    "A celestial being descended near **{loc}** and spoke a prophecy: *\"When the {f} falters, the darkness wakes.\"*",
+    "The **{f}** constructed a fortress at **{loc}** to guard the border. Its walls were said to be impenetrable."
+  ],
+  "medieval": [
+    "{n} crowned themselves ruler of **{loc}** after assassinating the previous monarch. The **{f}** backed the coup.",
+    "The **War of Three Banners** raged for twelve years. **{loc}** changed hands four times. The **{f}** emerged victorious — barely.",
+    "A trade route was established through **{loc}**, bringing wealth and trouble in equal measure. The **{f}** taxed it heavily.",
+    "{n} discovered that the ruling family of **{loc}** were secretly lycanthropes. The purge that followed was... thorough.",
+    "A tournament at **{loc}** ended in bloodshed when {n} accused the **{f}** of cheating. The grudge persists to this day.",
+    "The **{f}** built a cathedral at **{loc}** — ostensibly to worship, actually to conceal what lies beneath.",
+    "{n} negotiated the **Treaty of {loc}**, ending the border wars. Not everyone agreed with the terms. Some never forgave.",
+    "A band of adventurers destroyed a dragon's hoard near **{loc}**. The economic chaos that followed nearly toppled the **{f}**.",
+    "{n} was publicly executed at **{loc}** for heresy against the **{f}**. Their followers went underground — and multiplied.",
+    "The mines beneath **{loc}** broke through into something ancient. The **{f}** sealed them. {n} wants them reopened."
+  ],
+  "darkAge": [
+    "The **Shattering** — a magical cataclysm — devastated **{loc}**. The **{f}** was nearly wiped out. {n} led the survivors.",
+    "An undead army rose from the catacombs of **{loc}**. The siege lasted seven years. {n} held the gate alone on the final night.",
+    "A lich known as {n} established a domain of terror around **{loc}**. The **{f}** was formed specifically to oppose them.",
+    "Famine gripped the land for a decade. Near **{loc}**, the **{f}** hoarded grain while {n} distributed it to the starving — creating a schism.",
+    "The sun went dark for a month. Creatures of shadow poured from rifts near **{loc}**. {n} sealed the largest rift at the cost of their sight.",
+    "A demon lord was summoned at **{loc}** by a desperate cult. {n} and the **{f}** barely contained it. The scars on the land remain.",
+    "The **Red Winter** killed thousands near **{loc}**. Snow fell crimson for reasons no one could explain. The **{f}** blamed foreign sorcery.",
+    "All arcane magic failed for a year near **{loc}**. The **{f}** exploited the chaos while {n} searched for the cause."
+  ],
+  "recent": [
+    "{n} overthrew the old ruler of **{loc}**, establishing the **{f}** through blood and betrayal.",
+    "A great plague swept through **{loc}**. The **{f}** rose from the ashes, promising salvation — for a price.",
+    "An ancient artifact was unearthed near **{loc}**. The **{f}** claimed it, and {n} was changed by its power.",
+    "{n} was exiled from **{loc}** and founded the **{f}** in the wilderness, swearing vengeance.",
+    "The great fire of **{loc}** destroyed half the settlement. The **{f}** controls the reconstruction — and the debt.",
+    "A portal to the Shadowfell opened near **{loc}**. The **{f}** formed to guard it. {n} has not been the same since.",
+    "{n} discovered forbidden magic beneath **{loc}** and formed the **{f}** to study — or exploit — it.",
+    "The harvest failed for three years near **{loc}**. The **{f}** controls the food supply. {n} decides who eats.",
+    "A dragon attacked **{loc}**. {n} slew it — or so the stories say. The **{f}** was built on that legend.",
+    "{n} vanished from **{loc}** three months ago. The **{f}** is searching — some say to rescue, others say to silence.",
+    "Strange earthquakes have been shaking **{loc}**. The **{f}** blames {n}'s experiments. {n} blames something deeper.",
+    "A child was born at **{loc}** bearing the mark of an ancient prophecy. The **{f}** and {n} both want to control the child's fate."
+  ]
+}

--- a/app/src/main/assets/content/world/world-events.json
+++ b/app/src/main/assets/content/world/world-events.json
@@ -1,0 +1,79 @@
+{
+  "list": [
+    { "id": "faction_mobilizes", "weight": 3, "needs": "factions:>=2", "context": "faction-with-loc-discovered-pref",
+      "icon": "⚔️", "title": "{f.name} Mobilizes",
+      "prompt": "BREAKING: {f.name} is mobilizing troops near {loc.name}. NPC reactions should reflect fear, opportunity, or allegiance. Soldiers and supply wagons visible." },
+
+    { "id": "unexpected_alliance", "weight": 3, "needs": "factions:>=2", "context": "faction-pair",
+      "icon": "🤝", "title": "Unexpected Alliance",
+      "prompt": "BREAKING: {f1.name} and {f2.name} have declared a truce. NPCs are suspicious. Alliances shift power dynamics." },
+
+    { "id": "ruler_assassinated", "weight": 2, "needs": "factions:>=1", "context": "faction",
+      "icon": "💀", "title": "Ruler Assassinated",
+      "prompt": "BREAKING: The ruler of {f.name} is dead — assassinated. Power vacuum. Factions scramble. NPCs react with shock, fear, or ambition. THIS CHANGES EVERYTHING: faction prices double, guards are distracted (easier stealth), and a power-grab quest emerges." },
+
+    { "id": "demands_tribute", "weight": 2, "needs": "factions:>=1", "context": "faction",
+      "icon": "🏴", "title": "{f.name} Demands Tribute",
+      "prompt": "BREAKING: {f.name} is demanding tribute from settlements. Merchants complain. Guards enforce. Resistance is brewing. GAMEPLAY EFFECT: all NPC vendors now charge a 25% surcharge on goods. Refusing to pay the tribute collector triggers combat. A resistance contact quietly offers a quest to sabotage the collection effort." },
+
+    { "id": "border_clash", "weight": 2, "needs": "factions:>=2", "context": "faction-pair-with-typed-town-city",
+      "icon": "🔥", "title": "Border Clash near {loc.name}",
+      "prompt": "BREAKING: {f1.name} and {f2.name} fought a skirmish near {loc.name}. Refugees and wounded fill the roads. Pick a side or walk between. GAMEPLAY EFFECT: travel to {loc.name} costs double in supplies. Wounded soldiers offer equipment at a discount. Siding with either faction locks out that faction's rival merchants for 6 turns." },
+
+    { "id": "issues_edict", "weight": 2, "needs": "factions:>=1", "context": "faction-with-typed-town-city",
+      "icon": "📜", "title": "{f.name} Issues Edict",
+      "prompt": "BREAKING: {f.name} has issued a sweeping new edict affecting {loc.name}. NPCs whisper. Some obey. Some prepare to resist." },
+
+    { "id": "heretic_burning", "weight": 2, "needs": "factions:>=1", "context": "faction",
+      "icon": "🕯️", "title": "Heretic Burning",
+      "prompt": "BREAKING: {f.name} has burned a heretic in the public square. The smoke still rises. Sympathizers gather in shadows." },
+
+    { "id": "npc_vanished", "weight": 2, "needs": "npcs:>=1", "context": "npc",
+      "icon": "👤", "title": "{n.name} Has Vanished",
+      "prompt": "BREAKING: {n.name} the {n.role} vanished without a trace. Their quarters show signs of a struggle. Rumors fly. GAMEPLAY EFFECT: any quest tied to {n.name} is now blocked until they are found. A new investigation quest opens immediately. Their contacts offer a reward — and someone clearly doesn't want them found." },
+
+    { "id": "npc_speaks_out", "weight": 2, "needs": "npcs:>=1", "context": "npc",
+      "icon": "🗣️", "title": "{n.name} Speaks Out",
+      "prompt": "BREAKING: {n.name} the {n.role} has publicly denounced {n.faction}. Consequences are coming. Pick a side." },
+
+    { "id": "npc_betrothal", "weight": 2, "needs": "npcs:>=1", "context": "npc",
+      "icon": "💍", "title": "{n.name}'s Betrothal",
+      "prompt": "BREAKING: {n.name} the {n.role} has been betrothed. The alliance it seals shifts politics. Gifts and knives both travel fast." },
+
+    { "id": "npc_dead", "weight": 2, "needs": "npcs:>=1", "context": "npc",
+      "icon": "⚰️", "title": "{n.name} Is Dead",
+      "prompt": "BREAKING: {n.name} the {n.role} has died — cause disputed. Mourners gather. Suspects flee. Inheritance or revenge drives new quests." },
+
+    { "id": "fire_in_loc", "weight": 2, "needs": "loc:>=1", "context": "loc",
+      "icon": "🔥", "title": "Fire in {loc.name}",
+      "prompt": "BREAKING: Fire has swept part of {loc.name}. Smoke on the horizon. Refugees move along the roads. Arson is suspected. GAMEPLAY EFFECT: damaged buildings mean fewer merchants, displaced NPCs offer desperate quests, and fire damage lingers in scene descriptions for 5+ turns." },
+
+    { "id": "festival", "weight": 1, "needs": "loc:>=1", "context": "loc",
+      "icon": "🎪", "title": "Festival in {loc.name}",
+      "prompt": "BREAKING: A festival has begun in {loc.name}. Crowds, music, merchants, pickpockets. Rare goods and strangers in the streets." },
+
+    { "id": "monsters_spill", "weight": 2, "needs": "loc:typed-cave-dungeon-ruins", "context": "loc-typed-cave-dungeon-ruins",
+      "icon": "👹", "title": "Monsters Spill From {loc.name}",
+      "prompt": "BREAKING: Creatures have been sighted pouring from {loc.name}. Hunters are gathering. Bounties rise. Something deeper stirred. GAMEPLAY EFFECT: roads near {loc.name} trigger random encounters for the next 5 turns. Hunter NPCs pay premium for monster parts. A bounty board quest to clear the source is now active." },
+
+    { "id": "bounty_posted", "weight": 2, "needs": "loc:>=1", "context": "loc",
+      "icon": "📜", "title": "Bounty Posted at {loc.name}",
+      "prompt": "BREAKING: A substantial bounty has been posted at {loc.name}. Hunters and opportunists move in. The target knows they are prey." },
+
+    { "id": "storm", "weight": 1, "needs": "always", "context": "none",
+      "icon": "🌪️", "title": "Storm Sweeps the Land",
+      "prompt": "BREAKING: A freak storm is battering the countryside. Roads flood. Lightning strikes. Travel is treacherous." },
+
+    { "id": "unnatural_darkness", "weight": 1, "needs": "always", "context": "none",
+      "icon": "🌑", "title": "Unnatural Darkness",
+      "prompt": "BREAKING: For three hours at noon, the sky went dark. Priests pray. Astrologers argue. Something beyond the Veil took notice." },
+
+    { "id": "planar_rift", "weight": 1, "needs": "loc:>=1", "context": "loc",
+      "icon": "🌀", "title": "Planar Rift at {loc.name}",
+      "prompt": "BREAKING: A tear in reality has opened near {loc.name}. Things slip through — most shouldn't. Mages rush to study or seal it." },
+
+    { "id": "trade_route", "weight": 2, "needs": "always", "context": "none",
+      "icon": "💰", "title": "Trade Route Collapsed",
+      "prompt": "BREAKING: A key trade route has failed — raiders, rockslide, or political fiat. Prices spike. Merchants weep. Smugglers profit. GAMEPLAY EFFECT: all shop prices increase by 50% until resolved. New smuggler NPCs appear with black-market goods. A quest to reopen the route becomes available." }
+  ]
+}

--- a/app/src/main/kotlin/com/realmsoffate/game/data/content/ContentLoader.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/data/content/ContentLoader.kt
@@ -27,6 +27,8 @@ internal object ContentLoader {
         val spells: SpellsDto,
         val mutations: MutationsDto,
         val scenarios: ScenariosDto,
+        val worldEvents: WorldEventsDto,
+        val historicalEvents: HistoricalEvents,
     )
 
     fun loadAndValidate(open: (String) -> InputStream): Bundle {
@@ -48,6 +50,8 @@ internal object ContentLoader {
             spells = parse("content/spells/spells.json", open),
             mutations = parse("content/world/mutations.json", open),
             scenarios = parse("content/world/scenarios.json", open),
+            worldEvents = parse("content/world/world-events.json", open),
+            historicalEvents = parse("content/world/historical-events.json", open),
         )
     }
 

--- a/app/src/main/kotlin/com/realmsoffate/game/data/content/ContentRepository.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/data/content/ContentRepository.kt
@@ -57,4 +57,6 @@ object ContentRepository {
     val spells: List<Spell> get() = bundle.spells.list
     val mutations: List<Mutation> get() = bundle.mutations.list
     val scenarioMetas: List<ScenarioMeta> get() = bundle.scenarios.list
+    val worldEventTemplates: List<WorldEventTemplateDto> get() = bundle.worldEvents.list
+    val historicalEvents: HistoricalEvents get() = bundle.historicalEvents
 }

--- a/app/src/main/kotlin/com/realmsoffate/game/data/content/ContentSchema.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/data/content/ContentSchema.kt
@@ -6,7 +6,7 @@ import com.realmsoffate.game.game.RaceDef
 import com.realmsoffate.game.game.Spell
 import kotlinx.serialization.Serializable
 
-internal const val CONTENT_SCHEMA_VERSION = 4
+internal const val CONTENT_SCHEMA_VERSION = 5
 
 @Serializable
 internal data class SchemaVersionDto(val version: Int)
@@ -106,3 +106,26 @@ data class ScenarioMeta(
 
 @Serializable
 internal data class ScenariosDto(val list: List<ScenarioMeta>)
+
+@Serializable
+data class WorldEventTemplateDto(
+    val id: String,
+    val weight: Int,
+    val needs: String,
+    val context: String,
+    val icon: String,
+    val title: String,
+    val prompt: String,
+)
+
+@Serializable
+internal data class WorldEventsDto(val list: List<WorldEventTemplateDto>)
+
+@Serializable
+data class HistoricalEvents(
+    val primordial: List<String>,
+    val ancient: List<String>,
+    val medieval: List<String>,
+    val darkAge: List<String>,
+    val recent: List<String>,
+)

--- a/app/src/main/kotlin/com/realmsoffate/game/game/LoreGen.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/game/LoreGen.kt
@@ -10,6 +10,7 @@ import com.realmsoffate.game.data.WorldLore
 import com.realmsoffate.game.data.WorldMap
 import com.realmsoffate.game.data.content.ContentRepository
 import com.realmsoffate.game.data.content.EconState
+import com.realmsoffate.game.util.Templates
 import kotlin.random.Random
 
 private val FACTION_TYPES: List<String> get() = ContentRepository.factionTypes
@@ -35,69 +36,17 @@ private val WORLD_NAME_PATTERNS: List<(Random) -> String> = listOf(
 
 private val ERA_LABELS: List<String> get() = ContentRepository.eraLabels
 
-// ---- Primordial (6, as before) ----
-private val PRIMORDIAL_EVENTS: List<(String) -> String> = listOf(
-    { l -> "The gods shaped the land around **$l**. The earth still hums with their residual power." },
-    { l -> "A primordial titan fell near **$l**, its bones forming the bedrock. Its blood became the rivers." },
-    { l -> "The first elves emerged from the Feywild near **$l**, weeping at the beauty of the mortal sky." },
-    { l -> "Dragons claimed dominion over the region around **$l**. Their rule would last centuries." },
-    { l -> "The Weave of magic was woven across **$l** by unknown hands. Ley lines converge here still." },
-    { l -> "An ancient tree of immense power took root near **$l**. Druids would later name it the Worldheart." }
-)
+private val PRIMORDIAL_EVENTS: List<String> get() = ContentRepository.historicalEvents.primordial
+private val ANCIENT_EVENTS: List<String> get() = ContentRepository.historicalEvents.ancient
+private val MEDIEVAL_EVENTS: List<String> get() = ContentRepository.historicalEvents.medieval
+private val DARK_AGE_EVENTS: List<String> get() = ContentRepository.historicalEvents.darkAge
+private val RECENT_EVENTS: List<String> get() = ContentRepository.historicalEvents.recent
 
-// ---- Ancient (8) ----
-private val ANCIENT_EVENTS: List<(String, String, String) -> String> = listOf(
-    { f, n, loc -> "The **$f** was founded by $n after a divine vision at **$loc**. Its tenets still shape the region." },
-    { f, n, loc -> "A dwarven kingdom was carved beneath **$loc**. Its forges burned for a century before falling silent." },
-    { f, n, loc -> "$n united the warring tribes near **$loc** under the banner of the **$f**, forging the first alliance." },
-    { f, n, loc -> "The **Great Library of $loc** was built, housing knowledge from across the realm. The **$f** served as its guardians." },
-    { f, n, loc -> "An elven city rose near **$loc**, its towers touching the clouds. It would stand for five hundred years." },
-    { f, n, loc -> "$n discovered the first deposits of mythril beneath **$loc**, sparking a rush that transformed the region." },
-    { f, n, loc -> "A celestial being descended near **$loc** and spoke a prophecy: *\"When the $f falters, the darkness wakes.\"*" },
-    { f, n, loc -> "The **$f** constructed a fortress at **$loc** to guard the border. Its walls were said to be impenetrable." }
-)
+private fun renderPrimordial(template: String, loc: String): String =
+    Templates.interpolate(template, mapOf("loc" to loc))
 
-// ---- Medieval (10) ----
-private val MEDIEVAL_EVENTS: List<(String, String, String) -> String> = listOf(
-    { f, n, loc -> "$n crowned themselves ruler of **$loc** after assassinating the previous monarch. The **$f** backed the coup." },
-    { f, n, loc -> "The **War of Three Banners** raged for twelve years. **$loc** changed hands four times. The **$f** emerged victorious — barely." },
-    { f, n, loc -> "A trade route was established through **$loc**, bringing wealth and trouble in equal measure. The **$f** taxed it heavily." },
-    { f, n, loc -> "$n discovered that the ruling family of **$loc** were secretly lycanthropes. The purge that followed was... thorough." },
-    { f, n, loc -> "A tournament at **$loc** ended in bloodshed when $n accused the **$f** of cheating. The grudge persists to this day." },
-    { f, n, loc -> "The **$f** built a cathedral at **$loc** — ostensibly to worship, actually to conceal what lies beneath." },
-    { f, n, loc -> "$n negotiated the **Treaty of $loc**, ending the border wars. Not everyone agreed with the terms. Some never forgave." },
-    { f, n, loc -> "A band of adventurers destroyed a dragon's hoard near **$loc**. The economic chaos that followed nearly toppled the **$f**." },
-    { f, n, loc -> "$n was publicly executed at **$loc** for heresy against the **$f**. Their followers went underground — and multiplied." },
-    { f, n, loc -> "The mines beneath **$loc** broke through into something ancient. The **$f** sealed them. $n wants them reopened." }
-)
-
-// ---- Dark Age (8) ----
-private val DARK_AGE_EVENTS: List<(String, String, String) -> String> = listOf(
-    { f, n, loc -> "The **Shattering** — a magical cataclysm — devastated **$loc**. The **$f** was nearly wiped out. $n led the survivors." },
-    { f, n, loc -> "An undead army rose from the catacombs of **$loc**. The siege lasted seven years. $n held the gate alone on the final night." },
-    { f, n, loc -> "A lich known as $n established a domain of terror around **$loc**. The **$f** was formed specifically to oppose them." },
-    { f, n, loc -> "Famine gripped the land for a decade. Near **$loc**, the **$f** hoarded grain while $n distributed it to the starving — creating a schism." },
-    { f, n, loc -> "The sun went dark for a month. Creatures of shadow poured from rifts near **$loc**. $n sealed the largest rift at the cost of their sight." },
-    { f, n, loc -> "A demon lord was summoned at **$loc** by a desperate cult. $n and the **$f** barely contained it. The scars on the land remain." },
-    { f, n, loc -> "The **Red Winter** killed thousands near **$loc**. Snow fell crimson for reasons no one could explain. The **$f** blamed foreign sorcery." },
-    { f, n, loc -> "All arcane magic failed for a year near **$loc**. The **$f** exploited the chaos while $n searched for the cause." }
-)
-
-// ---- Recent (12) ----
-private val RECENT_EVENTS: List<(String, String, String) -> String> = listOf(
-    { f, n, loc -> "$n overthrew the old ruler of **$loc**, establishing the **$f** through blood and betrayal." },
-    { f, n, loc -> "A great plague swept through **$loc**. The **$f** rose from the ashes, promising salvation — for a price." },
-    { f, n, loc -> "An ancient artifact was unearthed near **$loc**. The **$f** claimed it, and $n was changed by its power." },
-    { f, n, loc -> "$n was exiled from **$loc** and founded the **$f** in the wilderness, swearing vengeance." },
-    { f, n, loc -> "The great fire of **$loc** destroyed half the settlement. The **$f** controls the reconstruction — and the debt." },
-    { f, n, loc -> "A portal to the Shadowfell opened near **$loc**. The **$f** formed to guard it. $n has not been the same since." },
-    { f, n, loc -> "$n discovered forbidden magic beneath **$loc** and formed the **$f** to study — or exploit — it." },
-    { f, n, loc -> "The harvest failed for three years near **$loc**. The **$f** controls the food supply. $n decides who eats." },
-    { f, n, loc -> "A dragon attacked **$loc**. $n slew it — or so the stories say. The **$f** was built on that legend." },
-    { f, n, loc -> "$n vanished from **$loc** three months ago. The **$f** is searching — some say to rescue, others say to silence." },
-    { f, n, loc -> "Strange earthquakes have been shaking **$loc**. The **$f** blames $n's experiments. $n blames something deeper." },
-    { f, n, loc -> "A child was born at **$loc** bearing the mark of an ancient prophecy. The **$f** and $n both want to control the child's fate." }
-)
+private fun renderEra(template: String, f: String, n: String, loc: String): String =
+    Templates.interpolate(template, mapOf("f" to f, "n" to n, "loc" to loc))
 
 private val RUMORS: List<String> get() = ContentRepository.rumors
 private val ECON_STATES: List<EconState> get() = ContentRepository.economyStates
@@ -227,7 +176,9 @@ object LoreGen {
         }
 
         // Primordial + era events
-        val primordial = PRIMORDIAL_EVENTS.shuffled(rand).take(3).map { it(worldMap.locations.first().name) }
+        val primordial = PRIMORDIAL_EVENTS.shuffled(rand).take(3).map {
+            renderPrimordial(it, worldMap.locations.first().name)
+        }
 
         val history = buildList {
             primordial.forEachIndexed { i, text ->
@@ -238,14 +189,14 @@ object LoreGen {
                 val f = factions.random(rand)
                 val n = NPC_FIRSTS.random(rand) + " " + NPC_TITLES.random(rand)
                 val loc = worldMap.locations.random(rand).name
-                add(HistoryEntry("ancient", -800 + it * 120 + rand.nextInt(40), ANCIENT_EVENTS.random(rand)(f.name, n, loc)))
+                add(HistoryEntry("ancient", -800 + it * 120 + rand.nextInt(40), renderEra(ANCIENT_EVENTS.random(rand), f.name, n, loc)))
             }
             repeat(4) {
                 if (factions.isEmpty()) return@repeat
                 val f = factions.random(rand)
                 val n = NPC_FIRSTS.random(rand) + " " + NPC_TITLES.random(rand)
                 val loc = worldMap.locations.random(rand).name
-                add(HistoryEntry("medieval", -400 + it * 80 + rand.nextInt(20), MEDIEVAL_EVENTS.random(rand)(f.name, n, loc)))
+                add(HistoryEntry("medieval", -400 + it * 80 + rand.nextInt(20), renderEra(MEDIEVAL_EVENTS.random(rand), f.name, n, loc)))
             }
             if (rand.nextFloat() < 0.7f) {
                 repeat(2) {
@@ -253,7 +204,7 @@ object LoreGen {
                     val f = factions.random(rand)
                     val n = NPC_FIRSTS.random(rand) + " " + NPC_TITLES.random(rand)
                     val loc = worldMap.locations.random(rand).name
-                    add(HistoryEntry("dark_age", -150 + it * 40 + rand.nextInt(10), DARK_AGE_EVENTS.random(rand)(f.name, n, loc)))
+                    add(HistoryEntry("dark_age", -150 + it * 40 + rand.nextInt(10), renderEra(DARK_AGE_EVENTS.random(rand), f.name, n, loc)))
                 }
             }
             repeat(3) {
@@ -261,7 +212,7 @@ object LoreGen {
                 val f = factions.random(rand)
                 val n = NPC_FIRSTS.random(rand) + " " + NPC_TITLES.random(rand)
                 val loc = worldMap.locations.random(rand).name
-                add(HistoryEntry("recent", -20 + it * 8 + rand.nextInt(4), RECENT_EVENTS.random(rand)(f.name, n, loc)))
+                add(HistoryEntry("recent", -20 + it * 8 + rand.nextInt(4), renderEra(RECENT_EVENTS.random(rand), f.name, n, loc)))
             }
         }.sortedBy { it.year }
 

--- a/app/src/main/kotlin/com/realmsoffate/game/game/WorldEvents.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/game/WorldEvents.kt
@@ -3,132 +3,92 @@ package com.realmsoffate.game.game
 import com.realmsoffate.game.data.WorldEvent
 import com.realmsoffate.game.data.WorldLore
 import com.realmsoffate.game.data.WorldMap
+import com.realmsoffate.game.data.content.ContentRepository
+import com.realmsoffate.game.data.content.WorldEventTemplateDto
+import com.realmsoffate.game.util.Templates
 import kotlin.random.Random
 
 /**
- * World events — 19 weighted templates across faction / NPC / location /
- * supernatural / economic / mutation-specific categories.
- *
- * Contextual triggers (travel/combat/time/quest) are surfaced by the caller
- * via a `baseChance` boost; the cooldown (min 8 turns) + +2%/turn since last
- * event ramp are built in.
+ * World events — weighted templates loaded from `assets/content/world/world-events.json`.
+ * Each JSON entry tags a `needs` predicate and a `context` picker; the registries below
+ * resolve those tags to lambdas. The runtime weighted-pick + cooldown ramp is unchanged
+ * from the pre-M5b implementation.
  */
-private data class EventTemplate(
-    val weight: Int,
-    val needs: (WorldLore, WorldMap) -> Boolean,
-    val gen: (WorldLore, WorldMap, Int) -> Triple<String, String, String>
-)
-
-private val templates = listOf(
-    // ---- FACTION (7)
-    EventTemplate(3, { l, _ -> l.factions.size >= 2 }) { l, wm, _ ->
-        val f = l.factions.random()
-        val loc = wm.locations.filter { it.discovered }.randomOrNull() ?: wm.locations.random()
-        Triple("⚔️", "${f.name} Mobilizes",
-            "BREAKING: ${f.name} is mobilizing troops near ${loc.name}. NPC reactions should reflect fear, opportunity, or allegiance. Soldiers and supply wagons visible.")
-    },
-    EventTemplate(3, { l, _ -> l.factions.size >= 2 }) { l, _, _ ->
-        val f1 = l.factions.random()
-        val f2 = l.factions.filter { it.name != f1.name }.randomOrNull() ?: f1
-        Triple("🤝", "Unexpected Alliance",
-            "BREAKING: ${f1.name} and ${f2.name} have declared a truce. NPCs are suspicious. Alliances shift power dynamics.")
-    },
-    EventTemplate(2, { l, _ -> l.factions.isNotEmpty() }) { l, _, _ ->
-        val f = l.factions.random()
-        Triple("💀", "Ruler Assassinated",
-            "BREAKING: The ruler of ${f.name} is dead — assassinated. Power vacuum. Factions scramble. NPCs react with shock, fear, or ambition. THIS CHANGES EVERYTHING: faction prices double, guards are distracted (easier stealth), and a power-grab quest emerges.")
-    },
-    EventTemplate(2, { l, _ -> l.factions.isNotEmpty() }) { l, _, _ ->
-        val f = l.factions.random()
-        Triple("🏴", "${f.name} Demands Tribute",
-            "BREAKING: ${f.name} is demanding tribute from settlements. Merchants complain. Guards enforce. Resistance is brewing. GAMEPLAY EFFECT: all NPC vendors now charge a 25% surcharge on goods. Refusing to pay the tribute collector triggers combat. A resistance contact quietly offers a quest to sabotage the collection effort.")
-    },
-    EventTemplate(2, { l, _ -> l.factions.size >= 2 }) { l, wm, _ ->
-        val f1 = l.factions.random()
-        val f2 = l.factions.filter { it.name != f1.name }.randomOrNull() ?: f1
-        val loc = wm.locations.filter { it.type in setOf("town", "city") }.randomOrNull() ?: wm.locations.random()
-        Triple("🔥", "Border Clash near ${loc.name}",
-            "BREAKING: ${f1.name} and ${f2.name} fought a skirmish near ${loc.name}. Refugees and wounded fill the roads. Pick a side or walk between. GAMEPLAY EFFECT: travel to ${loc.name} costs double in supplies. Wounded soldiers offer equipment at a discount. Siding with either faction locks out that faction's rival merchants for 6 turns.")
-    },
-    EventTemplate(2, { l, _ -> l.factions.isNotEmpty() }) { l, wm, _ ->
-        val f = l.factions.random()
-        val loc = wm.locations.filter { it.type in setOf("town", "city") }.randomOrNull() ?: wm.locations.random()
-        Triple("📜", "${f.name} Issues Edict",
-            "BREAKING: ${f.name} has issued a sweeping new edict affecting ${loc.name}. NPCs whisper. Some obey. Some prepare to resist.")
-    },
-    EventTemplate(2, { l, _ -> l.factions.isNotEmpty() }) { l, _, _ ->
-        val f = l.factions.random()
-        Triple("🕯️", "Heretic Burning",
-            "BREAKING: ${f.name} has burned a heretic in the public square. The smoke still rises. Sympathizers gather in shadows.")
-    },
-
-    // ---- NPC (4)
-    EventTemplate(2, { l, _ -> l.npcs.isNotEmpty() }) { l, _, _ ->
-        val n = l.npcs.random()
-        Triple("👤", "${n.name} Has Vanished",
-            "BREAKING: ${n.name} the ${n.role} vanished without a trace. Their quarters show signs of a struggle. Rumors fly. GAMEPLAY EFFECT: any quest tied to ${n.name} is now blocked until they are found. A new investigation quest opens immediately. Their contacts offer a reward — and someone clearly doesn't want them found.")
-    },
-    EventTemplate(2, { l, _ -> l.npcs.isNotEmpty() }) { l, _, _ ->
-        val n = l.npcs.random()
-        Triple("🗣️", "${n.name} Speaks Out",
-            "BREAKING: ${n.name} the ${n.role} has publicly denounced ${n.faction ?: "the crown"}. Consequences are coming. Pick a side.")
-    },
-    EventTemplate(2, { l, _ -> l.npcs.isNotEmpty() }) { l, _, _ ->
-        val n = l.npcs.random()
-        Triple("💍", "${n.name}'s Betrothal",
-            "BREAKING: ${n.name} the ${n.role} has been betrothed. The alliance it seals shifts politics. Gifts and knives both travel fast.")
-    },
-    EventTemplate(2, { l, _ -> l.npcs.isNotEmpty() }) { l, _, _ ->
-        val n = l.npcs.random()
-        Triple("⚰️", "${n.name} Is Dead",
-            "BREAKING: ${n.name} the ${n.role} has died — cause disputed. Mourners gather. Suspects flee. Inheritance or revenge drives new quests.")
-    },
-
-    // ---- LOCATION (4)
-    EventTemplate(2, { _, wm -> wm.locations.isNotEmpty() }) { _, wm, _ ->
-        val loc = wm.locations.random()
-        Triple("🔥", "Fire in ${loc.name}",
-            "BREAKING: Fire has swept part of ${loc.name}. Smoke on the horizon. Refugees move along the roads. Arson is suspected. GAMEPLAY EFFECT: damaged buildings mean fewer merchants, displaced NPCs offer desperate quests, and fire damage lingers in scene descriptions for 5+ turns.")
-    },
-    EventTemplate(1, { _, wm -> wm.locations.isNotEmpty() }) { _, wm, _ ->
-        val loc = wm.locations.random()
-        Triple("🎪", "Festival in ${loc.name}",
-            "BREAKING: A festival has begun in ${loc.name}. Crowds, music, merchants, pickpockets. Rare goods and strangers in the streets.")
-    },
-    EventTemplate(2, { _, wm -> wm.locations.any { it.type in setOf("dungeon", "cave", "ruins") } }) { _, wm, _ ->
-        val loc = wm.locations.filter { it.type in setOf("dungeon", "cave", "ruins") }.random()
-        Triple("👹", "Monsters Spill From ${loc.name}",
-            "BREAKING: Creatures have been sighted pouring from ${loc.name}. Hunters are gathering. Bounties rise. Something deeper stirred. GAMEPLAY EFFECT: roads near ${loc.name} trigger random encounters for the next 5 turns. Hunter NPCs pay premium for monster parts. A bounty board quest to clear the source is now active.")
-    },
-    EventTemplate(2, { _, wm -> wm.locations.isNotEmpty() }) { _, wm, _ ->
-        val loc = wm.locations.random()
-        Triple("📜", "Bounty Posted at ${loc.name}",
-            "BREAKING: A substantial bounty has been posted at ${loc.name}. Hunters and opportunists move in. The target knows they are prey.")
-    },
-
-    // ---- SUPERNATURAL (3)
-    EventTemplate(1, { _, _ -> true }) { _, _, _ ->
-        Triple("🌪️", "Storm Sweeps the Land",
-            "BREAKING: A freak storm is battering the countryside. Roads flood. Lightning strikes. Travel is treacherous.")
-    },
-    EventTemplate(1, { _, _ -> true }) { _, _, _ ->
-        Triple("🌑", "Unnatural Darkness",
-            "BREAKING: For three hours at noon, the sky went dark. Priests pray. Astrologers argue. Something beyond the Veil took notice.")
-    },
-    EventTemplate(1, { _, wm -> wm.locations.isNotEmpty() }) { _, wm, _ ->
-        val loc = wm.locations.random()
-        Triple("🌀", "Planar Rift at ${loc.name}",
-            "BREAKING: A tear in reality has opened near ${loc.name}. Things slip through — most shouldn't. Mages rush to study or seal it.")
-    },
-
-    // ---- ECONOMIC (1)
-    EventTemplate(2, { _, _ -> true }) { _, _, _ ->
-        Triple("💰", "Trade Route Collapsed",
-            "BREAKING: A key trade route has failed — raiders, rockslide, or political fiat. Prices spike. Merchants weep. Smugglers profit. GAMEPLAY EFFECT: all shop prices increase by 50% until resolved. New smuggler NPCs appear with black-market goods. A quest to reopen the route becomes available.")
-    }
-)
-
 object WorldEvents {
+
+    /** Eligibility predicates keyed by the JSON `needs` tag. */
+    private val needsRegistry: Map<String, (WorldLore, WorldMap) -> Boolean> = mapOf(
+        "always" to { _, _ -> true },
+        "factions:>=1" to { l, _ -> l.factions.isNotEmpty() },
+        "factions:>=2" to { l, _ -> l.factions.size >= 2 },
+        "npcs:>=1" to { l, _ -> l.npcs.isNotEmpty() },
+        "loc:>=1" to { _, wm -> wm.locations.isNotEmpty() },
+        "loc:typed-cave-dungeon-ruins" to { _, wm ->
+            wm.locations.any { it.type in CAVE_DUNGEON_RUINS }
+        },
+    )
+
+    /** Context pickers keyed by the JSON `context` tag. Each returns the
+     *  interpolation map to feed [Templates.interpolate] for the title/prompt. */
+    private val contextRegistry: Map<String, (WorldLore, WorldMap, Random) -> Map<String, String>> = mapOf(
+        "none" to { _, _, _ -> emptyMap() },
+
+        "faction" to { l, _, r ->
+            val f = l.factions.random(r)
+            mapOf("f.name" to f.name)
+        },
+
+        "faction-pair" to { l, _, r ->
+            val f1 = l.factions.random(r)
+            val f2 = l.factions.filter { it.name != f1.name }.randomOrNull(r) ?: f1
+            mapOf("f1.name" to f1.name, "f2.name" to f2.name)
+        },
+
+        "faction-with-loc-discovered-pref" to { l, wm, r ->
+            val f = l.factions.random(r)
+            val loc = wm.locations.filter { it.discovered }.randomOrNull(r)
+                ?: wm.locations.random(r)
+            mapOf("f.name" to f.name, "loc.name" to loc.name)
+        },
+
+        "faction-with-typed-town-city" to { l, wm, r ->
+            val f = l.factions.random(r)
+            val loc = wm.locations.filter { it.type in TOWN_CITY }.randomOrNull(r)
+                ?: wm.locations.random(r)
+            mapOf("f.name" to f.name, "loc.name" to loc.name)
+        },
+
+        "faction-pair-with-typed-town-city" to { l, wm, r ->
+            val f1 = l.factions.random(r)
+            val f2 = l.factions.filter { it.name != f1.name }.randomOrNull(r) ?: f1
+            val loc = wm.locations.filter { it.type in TOWN_CITY }.randomOrNull(r)
+                ?: wm.locations.random(r)
+            mapOf("f1.name" to f1.name, "f2.name" to f2.name, "loc.name" to loc.name)
+        },
+
+        "npc" to { l, _, r ->
+            val n = l.npcs.random(r)
+            mapOf(
+                "n.name" to n.name,
+                "n.role" to n.role,
+                "n.faction" to (n.faction ?: "the crown"),
+            )
+        },
+
+        "loc" to { _, wm, r ->
+            val loc = wm.locations.random(r)
+            mapOf("loc.name" to loc.name)
+        },
+
+        "loc-typed-cave-dungeon-ruins" to { _, wm, r ->
+            val loc = wm.locations.filter { it.type in CAVE_DUNGEON_RUINS }.random(r)
+            mapOf("loc.name" to loc.name)
+        },
+    )
+
+    private val TOWN_CITY = setOf("town", "city")
+    private val CAVE_DUNGEON_RUINS = setOf("dungeon", "cave", "ruins")
+
     /**
      * Chance ramps by +2%/turn since last event, capped by baseRate + maxBoost.
      * Minimum 8-turn cooldown.
@@ -141,15 +101,29 @@ object WorldEvents {
         val maxBoost = 0.30f
         val chance = (baseChance + sinceLast * 0.02f).coerceAtMost(baseChance + maxBoost)
         if (Random.nextFloat() > chance) return null
-        val eligible = templates.filter { it.needs(lore, wm) }
+
+        val templates = ContentRepository.worldEventTemplates
+        val eligible = templates.filter { resolveNeeds(it).invoke(lore, wm) }
         if (eligible.isEmpty()) return null
+
         val total = eligible.sumOf { it.weight }
         var pick = Random.nextInt(total)
         var chosen = eligible.first()
         for (t in eligible) {
             if (pick < t.weight) { chosen = t; break } else pick -= t.weight
         }
-        val (icon, title, prompt) = chosen.gen(lore, wm, currentTurn)
-        return WorldEvent(icon = icon, title = title, text = prompt, prompt = prompt, turn = currentTurn)
+
+        val ctx = resolveContext(chosen).invoke(lore, wm, Random)
+        val title = Templates.interpolate(chosen.title, ctx)
+        val prompt = Templates.interpolate(chosen.prompt, ctx)
+        return WorldEvent(icon = chosen.icon, title = title, text = prompt, prompt = prompt, turn = currentTurn)
     }
+
+    private fun resolveNeeds(t: WorldEventTemplateDto): (WorldLore, WorldMap) -> Boolean =
+        needsRegistry[t.needs]
+            ?: error("WorldEvents: unknown needs tag '${t.needs}' for id='${t.id}'")
+
+    private fun resolveContext(t: WorldEventTemplateDto): (WorldLore, WorldMap, Random) -> Map<String, String> =
+        contextRegistry[t.context]
+            ?: error("WorldEvents: unknown context tag '${t.context}' for id='${t.id}'")
 }

--- a/app/src/test/kotlin/com/realmsoffate/game/data/content/ContentRepositoryTest.kt
+++ b/app/src/test/kotlin/com/realmsoffate/game/data/content/ContentRepositoryTest.kt
@@ -53,6 +53,12 @@ class ContentRepositoryTest {
         assertTrue(ContentRepository.spells.isNotEmpty())
         assertTrue(ContentRepository.mutations.isNotEmpty())
         assertTrue(ContentRepository.scenarioMetas.isNotEmpty())
+        assertTrue(ContentRepository.worldEventTemplates.isNotEmpty())
+        assertTrue(ContentRepository.historicalEvents.primordial.isNotEmpty())
+        assertTrue(ContentRepository.historicalEvents.ancient.isNotEmpty())
+        assertTrue(ContentRepository.historicalEvents.medieval.isNotEmpty())
+        assertTrue(ContentRepository.historicalEvents.darkAge.isNotEmpty())
+        assertTrue(ContentRepository.historicalEvents.recent.isNotEmpty())
     }
 
     @Test

--- a/app/src/test/kotlin/com/realmsoffate/game/data/content/M5bContentParityTest.kt
+++ b/app/src/test/kotlin/com/realmsoffate/game/data/content/M5bContentParityTest.kt
@@ -1,0 +1,205 @@
+package com.realmsoffate.game.data.content
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.realmsoffate.game.util.Templates
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Parity tests pinning Phase 6 M5b JSON content to the historical Kotlin
+ * literals it replaced — WorldEvents weighted templates and the five
+ * LoreGen historical-event lists. Failures indicate JSON drift, not
+ * desired changes.
+ */
+@RunWith(RobolectricTestRunner::class)
+class M5bContentParityTest {
+
+    private val ctx: Context = ApplicationProvider.getApplicationContext()
+
+    @Before
+    fun init() {
+        ContentRepository.initialize(ctx)
+    }
+
+    @Test fun `world events match historical`() {
+        assertEquals(EXPECTED_WORLD_EVENTS, ContentRepository.worldEventTemplates)
+    }
+
+    @Test fun `historical events match historical literals`() {
+        val he = ContentRepository.historicalEvents
+        assertEquals(EXPECTED_PRIMORDIAL, he.primordial)
+        assertEquals(EXPECTED_ANCIENT, he.ancient)
+        assertEquals(EXPECTED_MEDIEVAL, he.medieval)
+        assertEquals(EXPECTED_DARK_AGE, he.darkAge)
+        assertEquals(EXPECTED_RECENT, he.recent)
+    }
+
+    @Test fun `every world event tag resolves`() {
+        // We can't reach the private registries, but we can prove resolution
+        // works by exercising the only public path: every tag set that ships
+        // should be one of the documented sets.
+        val knownNeeds = setOf("always", "factions:>=1", "factions:>=2", "npcs:>=1",
+            "loc:>=1", "loc:typed-cave-dungeon-ruins")
+        val knownContexts = setOf("none", "faction", "faction-pair",
+            "faction-with-loc-discovered-pref", "faction-with-typed-town-city",
+            "faction-pair-with-typed-town-city", "npc", "loc",
+            "loc-typed-cave-dungeon-ruins")
+        for (t in ContentRepository.worldEventTemplates) {
+            assertTrue("unknown needs tag '${t.needs}' on id='${t.id}'", t.needs in knownNeeds)
+            assertTrue("unknown context tag '${t.context}' on id='${t.id}'", t.context in knownContexts)
+        }
+    }
+
+    @Test fun `world event template renders as historical lambda would`() {
+        // Fixed inputs for the unexpected_alliance template (faction-pair).
+        val tpl = ContentRepository.worldEventTemplates.first { it.id == "unexpected_alliance" }
+        val ctxMap = mapOf("f1.name" to "The Iron Concordance", "f2.name" to "The Silent Order")
+        val title = Templates.interpolate(tpl.title, ctxMap)
+        val prompt = Templates.interpolate(tpl.prompt, ctxMap)
+        assertEquals("Unexpected Alliance", title)
+        assertEquals(
+            "BREAKING: The Iron Concordance and The Silent Order have declared a truce. " +
+                "NPCs are suspicious. Alliances shift power dynamics.",
+            prompt
+        )
+    }
+
+    @Test fun `historical event template renders as historical lambda would`() {
+        val tpl = EXPECTED_ANCIENT[0] // founder vision
+        val rendered = Templates.interpolate(
+            tpl,
+            mapOf("f" to "Iron Concordance", "n" to "Aenor Bright", "loc" to "Bastion")
+        )
+        assertEquals(
+            "The **Iron Concordance** was founded by Aenor Bright after a divine vision at **Bastion**. " +
+                "Its tenets still shape the region.",
+            rendered
+        )
+    }
+
+    private companion object {
+        val EXPECTED_WORLD_EVENTS: List<WorldEventTemplateDto> = listOf(
+            WorldEventTemplateDto("faction_mobilizes", 3, "factions:>=2", "faction-with-loc-discovered-pref",
+                "⚔️", "{f.name} Mobilizes",
+                "BREAKING: {f.name} is mobilizing troops near {loc.name}. NPC reactions should reflect fear, opportunity, or allegiance. Soldiers and supply wagons visible."),
+            WorldEventTemplateDto("unexpected_alliance", 3, "factions:>=2", "faction-pair",
+                "🤝", "Unexpected Alliance",
+                "BREAKING: {f1.name} and {f2.name} have declared a truce. NPCs are suspicious. Alliances shift power dynamics."),
+            WorldEventTemplateDto("ruler_assassinated", 2, "factions:>=1", "faction",
+                "💀", "Ruler Assassinated",
+                "BREAKING: The ruler of {f.name} is dead — assassinated. Power vacuum. Factions scramble. NPCs react with shock, fear, or ambition. THIS CHANGES EVERYTHING: faction prices double, guards are distracted (easier stealth), and a power-grab quest emerges."),
+            WorldEventTemplateDto("demands_tribute", 2, "factions:>=1", "faction",
+                "🏴", "{f.name} Demands Tribute",
+                "BREAKING: {f.name} is demanding tribute from settlements. Merchants complain. Guards enforce. Resistance is brewing. GAMEPLAY EFFECT: all NPC vendors now charge a 25% surcharge on goods. Refusing to pay the tribute collector triggers combat. A resistance contact quietly offers a quest to sabotage the collection effort."),
+            WorldEventTemplateDto("border_clash", 2, "factions:>=2", "faction-pair-with-typed-town-city",
+                "🔥", "Border Clash near {loc.name}",
+                "BREAKING: {f1.name} and {f2.name} fought a skirmish near {loc.name}. Refugees and wounded fill the roads. Pick a side or walk between. GAMEPLAY EFFECT: travel to {loc.name} costs double in supplies. Wounded soldiers offer equipment at a discount. Siding with either faction locks out that faction's rival merchants for 6 turns."),
+            WorldEventTemplateDto("issues_edict", 2, "factions:>=1", "faction-with-typed-town-city",
+                "📜", "{f.name} Issues Edict",
+                "BREAKING: {f.name} has issued a sweeping new edict affecting {loc.name}. NPCs whisper. Some obey. Some prepare to resist."),
+            WorldEventTemplateDto("heretic_burning", 2, "factions:>=1", "faction",
+                "🕯️", "Heretic Burning",
+                "BREAKING: {f.name} has burned a heretic in the public square. The smoke still rises. Sympathizers gather in shadows."),
+            WorldEventTemplateDto("npc_vanished", 2, "npcs:>=1", "npc",
+                "👤", "{n.name} Has Vanished",
+                "BREAKING: {n.name} the {n.role} vanished without a trace. Their quarters show signs of a struggle. Rumors fly. GAMEPLAY EFFECT: any quest tied to {n.name} is now blocked until they are found. A new investigation quest opens immediately. Their contacts offer a reward — and someone clearly doesn't want them found."),
+            WorldEventTemplateDto("npc_speaks_out", 2, "npcs:>=1", "npc",
+                "🗣️", "{n.name} Speaks Out",
+                "BREAKING: {n.name} the {n.role} has publicly denounced {n.faction}. Consequences are coming. Pick a side."),
+            WorldEventTemplateDto("npc_betrothal", 2, "npcs:>=1", "npc",
+                "💍", "{n.name}'s Betrothal",
+                "BREAKING: {n.name} the {n.role} has been betrothed. The alliance it seals shifts politics. Gifts and knives both travel fast."),
+            WorldEventTemplateDto("npc_dead", 2, "npcs:>=1", "npc",
+                "⚰️", "{n.name} Is Dead",
+                "BREAKING: {n.name} the {n.role} has died — cause disputed. Mourners gather. Suspects flee. Inheritance or revenge drives new quests."),
+            WorldEventTemplateDto("fire_in_loc", 2, "loc:>=1", "loc",
+                "🔥", "Fire in {loc.name}",
+                "BREAKING: Fire has swept part of {loc.name}. Smoke on the horizon. Refugees move along the roads. Arson is suspected. GAMEPLAY EFFECT: damaged buildings mean fewer merchants, displaced NPCs offer desperate quests, and fire damage lingers in scene descriptions for 5+ turns."),
+            WorldEventTemplateDto("festival", 1, "loc:>=1", "loc",
+                "🎪", "Festival in {loc.name}",
+                "BREAKING: A festival has begun in {loc.name}. Crowds, music, merchants, pickpockets. Rare goods and strangers in the streets."),
+            WorldEventTemplateDto("monsters_spill", 2, "loc:typed-cave-dungeon-ruins", "loc-typed-cave-dungeon-ruins",
+                "👹", "Monsters Spill From {loc.name}",
+                "BREAKING: Creatures have been sighted pouring from {loc.name}. Hunters are gathering. Bounties rise. Something deeper stirred. GAMEPLAY EFFECT: roads near {loc.name} trigger random encounters for the next 5 turns. Hunter NPCs pay premium for monster parts. A bounty board quest to clear the source is now active."),
+            WorldEventTemplateDto("bounty_posted", 2, "loc:>=1", "loc",
+                "📜", "Bounty Posted at {loc.name}",
+                "BREAKING: A substantial bounty has been posted at {loc.name}. Hunters and opportunists move in. The target knows they are prey."),
+            WorldEventTemplateDto("storm", 1, "always", "none",
+                "🌪️", "Storm Sweeps the Land",
+                "BREAKING: A freak storm is battering the countryside. Roads flood. Lightning strikes. Travel is treacherous."),
+            WorldEventTemplateDto("unnatural_darkness", 1, "always", "none",
+                "🌑", "Unnatural Darkness",
+                "BREAKING: For three hours at noon, the sky went dark. Priests pray. Astrologers argue. Something beyond the Veil took notice."),
+            WorldEventTemplateDto("planar_rift", 1, "loc:>=1", "loc",
+                "🌀", "Planar Rift at {loc.name}",
+                "BREAKING: A tear in reality has opened near {loc.name}. Things slip through — most shouldn't. Mages rush to study or seal it."),
+            WorldEventTemplateDto("trade_route", 2, "always", "none",
+                "💰", "Trade Route Collapsed",
+                "BREAKING: A key trade route has failed — raiders, rockslide, or political fiat. Prices spike. Merchants weep. Smugglers profit. GAMEPLAY EFFECT: all shop prices increase by 50% until resolved. New smuggler NPCs appear with black-market goods. A quest to reopen the route becomes available.")
+        )
+
+        val EXPECTED_PRIMORDIAL: List<String> = listOf(
+            "The gods shaped the land around **{loc}**. The earth still hums with their residual power.",
+            "A primordial titan fell near **{loc}**, its bones forming the bedrock. Its blood became the rivers.",
+            "The first elves emerged from the Feywild near **{loc}**, weeping at the beauty of the mortal sky.",
+            "Dragons claimed dominion over the region around **{loc}**. Their rule would last centuries.",
+            "The Weave of magic was woven across **{loc}** by unknown hands. Ley lines converge here still.",
+            "An ancient tree of immense power took root near **{loc}**. Druids would later name it the Worldheart."
+        )
+
+        val EXPECTED_ANCIENT: List<String> = listOf(
+            "The **{f}** was founded by {n} after a divine vision at **{loc}**. Its tenets still shape the region.",
+            "A dwarven kingdom was carved beneath **{loc}**. Its forges burned for a century before falling silent.",
+            "{n} united the warring tribes near **{loc}** under the banner of the **{f}**, forging the first alliance.",
+            "The **Great Library of {loc}** was built, housing knowledge from across the realm. The **{f}** served as its guardians.",
+            "An elven city rose near **{loc}**, its towers touching the clouds. It would stand for five hundred years.",
+            "{n} discovered the first deposits of mythril beneath **{loc}**, sparking a rush that transformed the region.",
+            "A celestial being descended near **{loc}** and spoke a prophecy: *\"When the {f} falters, the darkness wakes.\"*",
+            "The **{f}** constructed a fortress at **{loc}** to guard the border. Its walls were said to be impenetrable."
+        )
+
+        val EXPECTED_MEDIEVAL: List<String> = listOf(
+            "{n} crowned themselves ruler of **{loc}** after assassinating the previous monarch. The **{f}** backed the coup.",
+            "The **War of Three Banners** raged for twelve years. **{loc}** changed hands four times. The **{f}** emerged victorious — barely.",
+            "A trade route was established through **{loc}**, bringing wealth and trouble in equal measure. The **{f}** taxed it heavily.",
+            "{n} discovered that the ruling family of **{loc}** were secretly lycanthropes. The purge that followed was... thorough.",
+            "A tournament at **{loc}** ended in bloodshed when {n} accused the **{f}** of cheating. The grudge persists to this day.",
+            "The **{f}** built a cathedral at **{loc}** — ostensibly to worship, actually to conceal what lies beneath.",
+            "{n} negotiated the **Treaty of {loc}**, ending the border wars. Not everyone agreed with the terms. Some never forgave.",
+            "A band of adventurers destroyed a dragon's hoard near **{loc}**. The economic chaos that followed nearly toppled the **{f}**.",
+            "{n} was publicly executed at **{loc}** for heresy against the **{f}**. Their followers went underground — and multiplied.",
+            "The mines beneath **{loc}** broke through into something ancient. The **{f}** sealed them. {n} wants them reopened."
+        )
+
+        val EXPECTED_DARK_AGE: List<String> = listOf(
+            "The **Shattering** — a magical cataclysm — devastated **{loc}**. The **{f}** was nearly wiped out. {n} led the survivors.",
+            "An undead army rose from the catacombs of **{loc}**. The siege lasted seven years. {n} held the gate alone on the final night.",
+            "A lich known as {n} established a domain of terror around **{loc}**. The **{f}** was formed specifically to oppose them.",
+            "Famine gripped the land for a decade. Near **{loc}**, the **{f}** hoarded grain while {n} distributed it to the starving — creating a schism.",
+            "The sun went dark for a month. Creatures of shadow poured from rifts near **{loc}**. {n} sealed the largest rift at the cost of their sight.",
+            "A demon lord was summoned at **{loc}** by a desperate cult. {n} and the **{f}** barely contained it. The scars on the land remain.",
+            "The **Red Winter** killed thousands near **{loc}**. Snow fell crimson for reasons no one could explain. The **{f}** blamed foreign sorcery.",
+            "All arcane magic failed for a year near **{loc}**. The **{f}** exploited the chaos while {n} searched for the cause."
+        )
+
+        val EXPECTED_RECENT: List<String> = listOf(
+            "{n} overthrew the old ruler of **{loc}**, establishing the **{f}** through blood and betrayal.",
+            "A great plague swept through **{loc}**. The **{f}** rose from the ashes, promising salvation — for a price.",
+            "An ancient artifact was unearthed near **{loc}**. The **{f}** claimed it, and {n} was changed by its power.",
+            "{n} was exiled from **{loc}** and founded the **{f}** in the wilderness, swearing vengeance.",
+            "The great fire of **{loc}** destroyed half the settlement. The **{f}** controls the reconstruction — and the debt.",
+            "A portal to the Shadowfell opened near **{loc}**. The **{f}** formed to guard it. {n} has not been the same since.",
+            "{n} discovered forbidden magic beneath **{loc}** and formed the **{f}** to study — or exploit — it.",
+            "The harvest failed for three years near **{loc}**. The **{f}** controls the food supply. {n} decides who eats.",
+            "A dragon attacked **{loc}**. {n} slew it — or so the stories say. The **{f}** was built on that legend.",
+            "{n} vanished from **{loc}** three months ago. The **{f}** is searching — some say to rescue, others say to silence.",
+            "Strange earthquakes have been shaking **{loc}**. The **{f}** blames {n}'s experiments. {n} blames something deeper.",
+            "A child was born at **{loc}** bearing the mark of an ancient prophecy. The **{f}** and {n} both want to control the child's fate."
+        )
+    }
+}

--- a/docs/superpowers/specs/2026-05-01-phase6-json-content-m5b-design.md
+++ b/docs/superpowers/specs/2026-05-01-phase6-json-content-m5b-design.md
@@ -1,0 +1,211 @@
+# Phase 6 — JSON Content Extraction (M5b)
+
+**Date:** 2026-05-01
+**Issue:** [#24 — Extract hardcoded static data into JSON assets](https://github.com/tahuffman1s/RealmsAndroid/issues/24)
+**Scope:** Milestone M5b — WorldEvents + LoreGen historical events
+**Builds on:** M1+M2, M3, M4, M5a
+
+## Goal
+
+Finish the second half of the original M5 scope: move the 19-entry `WorldEvents` weighted template pool and the five LoreGen historical-event lambda lists (`PRIMORDIAL_EVENTS`, `ANCIENT_EVENTS`, `MEDIEVAL_EVENTS`, `DARK_AGE_EVENTS`, `RECENT_EVENTS`) out of Kotlin source into JSON.
+
+These are the lambda-based pools deferred all the way back from M2. The split between M5a (Mutations + Scenarios) and M5b (this) lets each PR stay reviewable.
+
+`WORLD_NAME_PATTERNS` in `LoreGen.kt` (eight inline-list-driven generators) is **out of scope** here — different shape, smaller payoff. It can fold into M6 or stay as code.
+
+## Decisions
+
+### WorldEvents
+
+The runtime template carries two lambdas:
+- `needs: (WorldLore, WorldMap) -> Boolean` — eligibility predicate
+- `gen: (WorldLore, WorldMap, Int) -> Triple<icon, title, prompt>` — picks random objects (faction/NPC/loc) and produces a `(icon, title, prompt)` triple.
+
+Approach: split each template into JSON-side **content** (icon string, title template, prompt template, weight) plus **context-tag** strings naming the eligibility predicate and the random-context picker. Both registries live in `WorldEvents.kt` keyed on the tag strings. Runtime joins them.
+
+| JSON field | Type | Purpose |
+|---|---|---|
+| `id` | String | Stable identifier; lets parity tests pin entries by id rather than ordinal. |
+| `weight` | Int | Forwarded to weighted pick. |
+| `needs` | String | Tag like `factions:>=2`, `npcs:>=1`, `loc:typed-cave`, `always`. Resolved via a code-side `needsRegistry`. |
+| `context` | String | Tag like `none`, `faction`, `faction-pair`, `faction-with-loc`, `faction-with-typed-loc`, `faction-pair-with-typed-loc`, `faction-with-discovered-loc`, `npc`, `loc`, `loc-typed-cave`. Resolved via a code-side `contextRegistry`. The picker returns a `Map<String, String>` for interpolation. |
+| `icon` | String | Static. Goes straight into the `WorldEvent.icon` field. |
+| `title` | String | Template with `{f.name}`, `{n.name}`, `{loc.name}` etc. placeholders, interpolated with the context map. |
+| `prompt` | String | Same as title — full text body. |
+
+Both registries use a small fixed enum set; adding a JSON entry with an unknown tag fails fast at first access (mirrors M3/M5a registry-drift checks).
+
+The 19 templates require:
+- **needs tags:** `always`, `factions:>=1`, `factions:>=2`, `npcs:>=1`, `loc:>=1`, `loc:typed-cave-dungeon-ruins`.
+- **context tags:** `none`, `faction`, `faction-pair`, `faction-with-loc`, `faction-with-loc-discovered-pref`, `faction-with-typed-town-city`, `faction-pair-with-typed-town-city`, `npc`, `loc`, `loc-typed-cave-dungeon-ruins`.
+
+### LoreGen historical events
+
+Five `List<(String, ...) -> String>` lambda lists. `PRIMORDIAL_EVENTS` is `(loc) -> String`; the other four are `(f, n, loc) -> String`. All five are simple template-string lists with `{loc}` / `{f}` / `{n}` placeholders.
+
+Single asset file `world/historical-events.json`:
+
+```json
+{
+  "primordial": [ "The gods shaped the land around **{loc}**.", ... ],
+  "ancient":   [ "The **{f}** was founded by {n}...", ... ],
+  "medieval":  [ ... ],
+  "darkAge":   [ ... ],
+  "recent":    [ ... ]
+}
+```
+
+`LoreGen` swaps the five `private val *_EVENTS` lambda lists for top-level facade properties that read `ContentRepository.historicalEvents.<era>` and interpolate at the call site (the four call sites already pick a random template and apply it to `(f, n, loc)`).
+
+### Schema
+
+Bump `CONTENT_SCHEMA_VERSION` 4 → 5.
+
+## What moves
+
+```
+app/src/main/assets/content/
+├── schema-version.json                 (bump → {"version": 5})
+└── world/
+    ├── world-events.json               (NEW — 19 entries)
+    └── historical-events.json          (NEW — primordial 6, ancient 8, medieval 10, dark_age 8, recent 12)
+```
+
+Source-side:
+
+```
+app/src/main/kotlin/com/realmsoffate/game/
+├── data/content/
+│   ├── ContentSchema.kt                (bump version, add WorldEventDto + HistoricalEventsDto)
+│   ├── ContentLoader.kt                (parse 2 new files)
+│   └── ContentRepository.kt            (expose worldEventTemplates, historicalEvents)
+└── game/
+    ├── WorldEvents.kt                  (gen lambda → registry; reads from ContentRepository)
+    └── LoreGen.kt                      (5 *_EVENTS lambda lists → facades over ContentRepository.historicalEvents.<era>)
+```
+
+Tests:
+
+```
+app/src/test/kotlin/com/realmsoffate/game/data/content/
+├── ContentRepositoryTest.kt            (add non-empty asserts for both)
+└── M5bContentParityTest.kt             (NEW — pin both lists + render-template sample)
+```
+
+## Schema additions
+
+```kotlin
+internal const val CONTENT_SCHEMA_VERSION = 5
+
+@Serializable
+data class WorldEventTemplateDto(
+    val id: String,
+    val weight: Int,
+    val needs: String,
+    val context: String,
+    val icon: String,
+    val title: String,
+    val prompt: String,
+)
+
+@Serializable
+internal data class WorldEventsDto(val list: List<WorldEventTemplateDto>)
+
+@Serializable
+data class HistoricalEvents(
+    val primordial: List<String>,
+    val ancient: List<String>,
+    val medieval: List<String>,
+    val darkAge: List<String>,
+    val recent: List<String>,
+)
+```
+
+`ContentRepository`:
+
+```kotlin
+val worldEventTemplates: List<WorldEventTemplateDto> get() = bundle.worldEvents.list
+val historicalEvents: HistoricalEvents get() = bundle.historicalEvents
+```
+
+## WorldEvents.kt rewrite sketch
+
+```kotlin
+private val needsRegistry: Map<String, (WorldLore, WorldMap) -> Boolean> = mapOf(
+    "always"                          to { _, _ -> true },
+    "factions:>=1"                    to { l, _ -> l.factions.isNotEmpty() },
+    "factions:>=2"                    to { l, _ -> l.factions.size >= 2 },
+    "npcs:>=1"                        to { l, _ -> l.npcs.isNotEmpty() },
+    "loc:>=1"                         to { _, wm -> wm.locations.isNotEmpty() },
+    "loc:typed-cave-dungeon-ruins"    to { _, wm -> wm.locations.any { it.type in setOf("dungeon", "cave", "ruins") } },
+)
+
+private val contextRegistry: Map<String, (WorldLore, WorldMap, Random) -> Map<String, String>> = mapOf(
+    "none" to { _, _, _ -> emptyMap() },
+    "faction" to { l, _, r ->
+        val f = l.factions.random(r)
+        mapOf("f.name" to f.name)
+    },
+    "faction-pair" to { l, _, r ->
+        val f1 = l.factions.random(r)
+        val f2 = l.factions.filter { it.name != f1.name }.randomOrNull(r) ?: f1
+        mapOf("f1.name" to f1.name, "f2.name" to f2.name)
+    },
+    // ... etc for the other 7 context tags
+)
+
+fun maybeGenerate(...): WorldEvent? {
+    // weighted-pick + cooldown unchanged
+    val tpl = chosen
+    val needs = needsRegistry[tpl.needs] ?: error("unknown needs tag '${tpl.needs}'")
+    val context = contextRegistry[tpl.context] ?: error("unknown context tag '${tpl.context}'")
+    val rng = Random
+    val ctx = context(lore, wm, rng)
+    val title = Templates.interpolate(tpl.title, ctx)
+    val prompt = Templates.interpolate(tpl.prompt, ctx)
+    return WorldEvent(icon = tpl.icon, title = title, text = prompt, prompt = prompt, turn = currentTurn)
+}
+```
+
+## LoreGen.kt diffs
+
+Replace each `private val PRIMORDIAL_EVENTS = listOf<(String) -> String>(...)` with a getter:
+
+```kotlin
+private val PRIMORDIAL_EVENTS: List<String> get() = ContentRepository.historicalEvents.primordial
+```
+
+Call sites change from `PRIMORDIAL_EVENTS.shuffled(rand).take(3).map { it(loc) }` to:
+
+```kotlin
+PRIMORDIAL_EVENTS.shuffled(rand).take(3).map { Templates.interpolate(it, mapOf("loc" to firstLoc)) }
+```
+
+Same shape for the other four. Three call sites in `LoreGen.generate` switch from `lambda(f.name, n, loc)` to `Templates.interpolate(template, mapOf("f" to f.name, "n" to n, "loc" to loc))`.
+
+## Tests
+
+| Test | Purpose |
+|---|---|
+| `ContentRepositoryTest.parsesAllShippedAssets` | Add non-empty asserts for `worldEventTemplates`, `historicalEvents.*`. |
+| `M5bContentParityTest.world events match historical` | `ContentRepository.worldEventTemplates` equals expected list (19 entries). |
+| `M5bContentParityTest.historical events match historical` | All five lists equal historical Kotlin literals (with `{}` placeholders). |
+| `M5bContentParityTest.world event needs and context tags resolve` | Every template's needs/context tag is present in their respective registry. |
+| `M5bContentParityTest.world event sample renders correctly` | Pin a known event id (e.g. `unexpected_alliance`) — fixed seed, fixed lore — and assert the rendered title + prompt match the historical lambda's output. |
+
+## Acceptance
+
+- [ ] `ContentRepository.worldEventTemplates`, `.historicalEvents.{primordial,ancient,medieval,darkAge,recent}` exposed and non-empty.
+- [ ] Both new asset files ship with full historical content; schema version is `{"version": 5}`.
+- [ ] `WorldEvents.maybeGenerate` returns the same shape `WorldEvent` it always did, driven by JSON templates and tag registries.
+- [ ] `LoreGen.generate` produces lore where historical entries are interpolated from JSON templates instead of in-source lambdas.
+- [ ] All M5b parity tests pass.
+- [ ] `gradle test`, `gradle assembleDebug` pass.
+- [ ] App boots; `/macro/new-game` works (does not exercise these lambdas directly because the macro short-circuits world-gen, but asset load must not crash).
+- [ ] APK delta ≤ 50 KB (epic budget).
+
+## Out of scope
+
+- `WORLD_NAME_PATTERNS` in `LoreGen.kt`. Defer.
+- Hot-reload (M6).
+- Facade deletion + epic seeded-output parity (M7).


### PR DESCRIPTION
## Summary
- Moves the 19-entry `WorldEvents` weighted template pool and the five `LoreGen` historical-event lambda lists (`PRIMORDIAL` 6 / `ANCIENT` 8 / `MEDIEVAL` 10 / `DARK_AGE` 8 / `RECENT` 12 — 44 entries total) into JSON. Schema bumped 4 → 5.
- WorldEvents now ships per-template `needs` and `context` tags; code-side registries (`needsRegistry`, `contextRegistry`) resolve tags to eligibility predicates and random-object pickers. Templates.interpolate fills `{f.name}` / `{n.name}` / `{loc.name}` placeholders. Weighted-pick + 8-turn cooldown ramp unchanged.
- LoreGen's five `*_EVENTS` lambda lists collapse to getters that read `List<String>` templates from `ContentRepository.historicalEvents`. Call sites use new `renderEra` / `renderPrimordial` helpers.
- New assets total ~12 KB.

This finishes the original M5 scope. `WORLD_NAME_PATTERNS` in LoreGen is still in code (different shape, smaller payoff — defer to M6 or fold into a follow-up).

Builds on M1+M2/M3/M4/M5a (#24). Design at `docs/superpowers/specs/2026-05-01-phase6-json-content-m5b-design.md`.

## Test plan
- [x] `gradle test` — all passing, including new `M5bContentParityTest` pinning 19 world-event templates and all five era lists verbatim
- [x] `M5bContentParityTest.world event template renders as historical lambda would` and `historical event template renders as historical lambda would` — byte-for-byte parity for fixed inputs
- [x] `M5bContentParityTest.every world event tag resolves` — every JSON `needs` and `context` tag is one of the documented set
- [x] `gradle assembleDebug`
- [x] Deployed to `emulator-5554`; P0 (`/state` HTTP 200) + P1 (state JSON + screenshot) green
- [x] Contextual: `/macro/simulate-gameplay` completed cleanly (24 turns, 9 messages) — exercises the LoreGen + WorldEvents JSON load paths under simulated mid-campaign state
- [x] APK asset delta ~12 KB (under epic 50 KB budget)

Refs #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)