### PR TITLE
feat(phase6): JSON content extraction M6 — debug-only hot-reload

### DIFF
--- a/app/src/debug/kotlin/com/realmsoffate/game/debug/ContentEndpoints.kt
+++ b/app/src/debug/kotlin/com/realmsoffate/game/debug/ContentEndpoints.kt
@@ -1,0 +1,53 @@
+package com.realmsoffate.game.debug
+
+import com.realmsoffate.game.data.content.ContentException
+import com.realmsoffate.game.data.content.ContentInfo
+import com.realmsoffate.game.data.content.ContentRepository
+
+/**
+ * Phase 6 M6 — debug-only endpoints for the JSON-content hot-reload system.
+ *
+ *  GET  /content/info      Snapshot of schema version, override-enabled flag,
+ *                          override root path, and per-file source map (each
+ *                          shipped path resolved as either "asset" or "override").
+ *
+ *  POST /content/reload    Re-runs ContentRepository.initialize(allowOverride=true)
+ *                          against the current Application. Atomic: if the new
+ *                          bundle fails to parse / validate, the prior bundle
+ *                          stays live and the endpoint returns 409 with the
+ *                          underlying ContentException message.
+ */
+object ContentEndpoints {
+    fun register() {
+        DebugServer.route("GET", "/content/info") { _ ->
+            HttpResponse.json(ContentRepository.info().toJson())
+        }
+
+        DebugServer.route("POST", "/content/reload") { _ ->
+            val app = DebugBridge.requireActivity().application
+            try {
+                ContentRepository.initialize(app, allowOverride = true)
+                HttpResponse.json("""{"ok":true,"info":${ContentRepository.info().toJson()}}""")
+            } catch (e: ContentException) {
+                HttpResponse.error(409, "reload failed: ${e.message?.replace("\"", "\\\"") ?: e::class.simpleName}")
+            }
+        }
+    }
+}
+
+private fun ContentInfo.toJson(): String = buildString {
+    append("{")
+    append("\"schemaVersion\":").append(schemaVersion).append(',')
+    append("\"overrideEnabled\":").append(overrideEnabled).append(',')
+    append("\"overrideRoot\":")
+    if (overrideRoot == null) append("null") else append('"').append(overrideRoot.jsonEscape()).append('"')
+    append(',')
+    append("\"sources\":{")
+    sources.entries.forEachIndexed { i, (path, src) ->
+        if (i > 0) append(',')
+        append('"').append(path.jsonEscape()).append("\":\"").append(src).append('"')
+    }
+    append("}}")
+}
+
+private fun String.jsonEscape(): String = replace("\\", "\\\\").replace("\"", "\\\"")

--- a/app/src/debug/kotlin/com/realmsoffate/game/debug/DebugServer.kt
+++ b/app/src/debug/kotlin/com/realmsoffate/game/debug/DebugServer.kt
@@ -63,6 +63,7 @@ object DebugServer {
         DescribeEndpoints.register()
         RepoEndpoints.register()
         AiDebugEndpoints.register()
+        ContentEndpoints.register()
 
         scope.launch {
             try {

--- a/app/src/main/kotlin/com/realmsoffate/game/RealmsApp.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/RealmsApp.kt
@@ -13,7 +13,7 @@ class RealmsApp : Application() {
     override fun onCreate() {
         super.onCreate()
         INSTANCE = this
-        ContentRepository.initialize(this)
+        ContentRepository.initialize(this, allowOverride = BuildConfig.DEBUG)
         EmojiCompat.init(BundledEmojiCompatConfig(this, Executors.newSingleThreadExecutor()))
         SaveStore.init(this)
         RealmsDbHolder.init(this)

--- a/app/src/main/kotlin/com/realmsoffate/game/data/content/ContentRepository.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/data/content/ContentRepository.kt
@@ -5,18 +5,67 @@ import com.realmsoffate.game.game.ClassDef
 import com.realmsoffate.game.game.Mutation
 import com.realmsoffate.game.game.RaceDef
 import com.realmsoffate.game.game.Spell
+import java.io.File
+import java.io.InputStream
 
 object ContentRepository {
 
     private lateinit var bundle: ContentLoader.Bundle
 
-    fun initialize(context: Context) {
-        bundle = ContentLoader.loadAndValidate { path -> context.assets.open(path) }
+    /** Filesystem root for hot-reload overrides; null when override is disabled. */
+    private var overrideRoot: File? = null
+
+    /** Per-path provenance from the most recent successful load: "asset" | "override". */
+    private var sourceMap: Map<String, String> = emptyMap()
+
+    /**
+     * Load content into memory.
+     *
+     * When [allowOverride] is true (debug builds), each requested path is checked
+     * against `<filesDir>/content/<path-without-content-prefix>` first; missing
+     * override files fall through to the bundled APK assets. Per-file overlay —
+     * writers can drop a single JSON without supplying the rest.
+     *
+     * Reload is atomic. If the new bundle fails to parse / validate, the prior
+     * bundle is left untouched and the underlying [ContentException] propagates.
+     */
+    fun initialize(context: Context, allowOverride: Boolean = false) {
+        val root = if (allowOverride) File(context.filesDir, "content") else null
+        loadInto(root) { path -> context.assets.open(path) }
     }
 
-    internal fun initializeFrom(open: (String) -> java.io.InputStream) {
-        bundle = ContentLoader.loadAndValidate(open)
+    internal fun initializeFrom(open: (String) -> InputStream) {
+        loadInto(overrideRoot = null, assetOpen = open)
     }
+
+    @Synchronized
+    private fun loadInto(overrideRoot: File?, assetOpen: (String) -> InputStream) {
+        val recordedSources = mutableMapOf<String, String>()
+        val opener: (String) -> InputStream = { path ->
+            val rel = path.removePrefix("content/")
+            val overrideFile = overrideRoot?.let { File(it, rel) }?.takeIf { it.isFile }
+            if (overrideFile != null) {
+                recordedSources[path] = "override"
+                overrideFile.inputStream()
+            } else {
+                recordedSources[path] = "asset"
+                assetOpen(path)
+            }
+        }
+        // Throws ContentException on failure; bundle reference only updates on success.
+        val newBundle = ContentLoader.loadAndValidate(opener)
+        bundle = newBundle
+        this.overrideRoot = overrideRoot
+        this.sourceMap = recordedSources.toMap()
+    }
+
+    /** Snapshot of current load metadata — schema version, override status, per-file source. */
+    fun info(): ContentInfo = ContentInfo(
+        schemaVersion = CONTENT_SCHEMA_VERSION,
+        overrideEnabled = overrideRoot != null,
+        overrideRoot = overrideRoot?.absolutePath,
+        sources = sourceMap,
+    )
 
     val factionTypes: List<String> get() = bundle.factions.types
     val factionAdjectives: List<String> get() = bundle.factions.adjectives

--- a/app/src/main/kotlin/com/realmsoffate/game/data/content/ContentSchema.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/data/content/ContentSchema.kt
@@ -121,6 +121,14 @@ data class WorldEventTemplateDto(
 @Serializable
 internal data class WorldEventsDto(val list: List<WorldEventTemplateDto>)
 
+/** Snapshot of [ContentRepository] load state — used by debug-bridge `/content/info`. */
+data class ContentInfo(
+    val schemaVersion: Int,
+    val overrideEnabled: Boolean,
+    val overrideRoot: String?,
+    val sources: Map<String, String>,
+)
+
 @Serializable
 data class HistoricalEvents(
     val primordial: List<String>,

--- a/app/src/test/kotlin/com/realmsoffate/game/data/content/HotReloadTest.kt
+++ b/app/src/test/kotlin/com/realmsoffate/game/data/content/HotReloadTest.kt
@@ -1,0 +1,117 @@
+package com.realmsoffate.game.data.content
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+
+/**
+ * Phase 6 M6 — verifies the debug-only `filesDir/content/` overlay short-circuits
+ * the bundled assets per-file, propagates schema mismatches without dropping the
+ * prior bundle, and is a no-op when [ContentRepository.initialize] is called with
+ * `allowOverride = false`.
+ */
+@RunWith(RobolectricTestRunner::class)
+class HotReloadTest {
+
+    private val ctx: Context = ApplicationProvider.getApplicationContext()
+    private val overrideRoot: File = File(ctx.filesDir, "content")
+
+    @After
+    fun tearDown() {
+        // Clear any test-written override files between cases and restore default load.
+        if (overrideRoot.exists()) overrideRoot.deleteRecursively()
+        ContentRepository.initialize(ctx, allowOverride = false)
+    }
+
+    @Test
+    fun `override file wins over bundled asset`() {
+        writeOverride(
+            "world/mutations.json",
+            """{"list":[{"id":"hot_test","name":"Hot Test","icon":"🔁","desc":"override","prompt":"OVERRIDE PROMPT"}]}"""
+        )
+
+        ContentRepository.initialize(ctx, allowOverride = true)
+
+        assertEquals(1, ContentRepository.mutations.size)
+        assertEquals("hot_test", ContentRepository.mutations[0].id)
+        assertEquals("override", ContentRepository.info().sources["content/world/mutations.json"])
+    }
+
+    @Test
+    fun `missing override files fall through to bundled assets`() {
+        // Override directory exists but no files inside.
+        overrideRoot.mkdirs()
+
+        ContentRepository.initialize(ctx, allowOverride = true)
+
+        assertTrue(ContentRepository.mutations.size >= 16) // bundled count is 16
+        val info = ContentRepository.info()
+        assertTrue(info.overrideEnabled)
+        assertTrue(info.sources.values.all { it == "asset" })
+    }
+
+    @Test
+    fun `override schema mismatch raises and preserves prior bundle`() {
+        // Establish a known-good bundle first.
+        ContentRepository.initialize(ctx, allowOverride = false)
+        val priorMutationCount = ContentRepository.mutations.size
+
+        writeOverride("schema-version.json", """{"version": 999}""")
+
+        assertThrows(ContentException.SchemaVersionMismatch::class.java) {
+            ContentRepository.initialize(ctx, allowOverride = true)
+        }
+
+        // Prior bundle stays queryable — atomic reload contract.
+        assertEquals(priorMutationCount, ContentRepository.mutations.size)
+    }
+
+    @Test
+    fun `disabled override ignores filesDir contents`() {
+        writeOverride(
+            "world/mutations.json",
+            """{"list":[{"id":"should_be_ignored","name":"x","icon":"x","desc":"x","prompt":"x"}]}"""
+        )
+
+        ContentRepository.initialize(ctx, allowOverride = false)
+
+        assertNotEquals("should_be_ignored", ContentRepository.mutations.first().id)
+        assertTrue(ContentRepository.mutations.size >= 16)
+        val info = ContentRepository.info()
+        assertEquals(false, info.overrideEnabled)
+        assertEquals(null, info.overrideRoot)
+    }
+
+    @Test
+    fun `info reports per-file override source`() {
+        writeOverride(
+            "world/mutations.json",
+            """{"list":[{"id":"x","name":"x","icon":"x","desc":"x","prompt":"x"}]}"""
+        )
+
+        ContentRepository.initialize(ctx, allowOverride = true)
+
+        val sources = ContentRepository.info().sources
+        assertEquals("override", sources["content/world/mutations.json"])
+        // Adjacent files in the same folder should still be coming from the asset.
+        assertEquals("asset", sources["content/world/scenarios.json"])
+        // Schema file too.
+        assertEquals("asset", sources["content/schema-version.json"])
+    }
+
+    private fun writeOverride(relativePath: String, body: String) {
+        val target = File(overrideRoot, relativePath)
+        target.parentFile?.mkdirs()
+        target.writeText(body, Charsets.UTF_8)
+        assertNotNull(target.parentFile)
+    }
+}

--- a/docs/superpowers/specs/2026-05-01-phase6-json-content-m6-design.md
+++ b/docs/superpowers/specs/2026-05-01-phase6-json-content-m6-design.md
@@ -1,0 +1,142 @@
+# Phase 6 — JSON Content Extraction (M6)
+
+**Date:** 2026-05-01
+**Issue:** [#24 — Extract hardcoded static data into JSON assets](https://github.com/tahuffman1s/RealmsAndroid/issues/24)
+**Scope:** Milestone M6 — Debug-only hot-reload of content from `Context.filesDir`
+**Builds on:** M1+M2, M3, M4, M5a, M5b
+
+## Goal
+
+Let writers (and engineers) edit a content JSON, push it to the device, hit a debug-bridge endpoint, and see the change on the next access — without rebuilding the APK. Production builds are unaffected.
+
+## Decisions
+
+| Decision | Choice |
+|---|---|
+| Override directory | `Context.filesDir/content/`. Mirrors the asset layout exactly: `content/lore/factions.json` is overridden by `<filesDir>/content/lore/factions.json`. |
+| Build-flavor gate | Override only enabled when `BuildConfig.DEBUG`. `RealmsApp.onCreate` passes `BuildConfig.DEBUG` into `ContentRepository.initialize` as the `allowOverride` flag. Release builds always use the bundled assets. |
+| Per-file or full-bundle override | **Per-file.** The overlay opener checks the override location first and falls back to assets per path. Writers can drop a single `factions.json` into `filesDir/content/lore/` and leave everything else unchanged. |
+| Schema version on override | `schema-version.json` is part of the same overlay. If the override file declares a version that doesn't match `CONTENT_SCHEMA_VERSION`, the reload fails with `SchemaVersionMismatch`. No silent fallback to bundled. |
+| Failure behavior on reload | If parsing the new bundle throws, the *current* bundle is left untouched and the endpoint returns the diagnostic. Reload is atomic. |
+| Source-of-truth visibility | A `GET /content/info` endpoint reports the active schema version and which paths are coming from the override vs. the bundled assets. |
+| Endpoint surface | `GET /content/info`, `POST /content/reload`. Both live in a new `ContentEndpoints.kt` under `app/src/debug/`. |
+| Concurrency | `initialize` and `reload` are synchronized on `ContentRepository`. Readers see whichever bundle is current at the moment of property access — no stale snapshots can be torn because every public accessor reads through `bundle` once. |
+
+## Why no schema version bump
+
+M6 ships only a code change — no new JSON shapes, no new assets, no new fields. The shipped content stays at version 5. Override files must declare `version: 5` to load.
+
+## Implementation sketch
+
+### `ContentRepository.initialize(context, allowOverride)`
+
+```kotlin
+fun initialize(context: Context, allowOverride: Boolean = false) {
+    val overrideRoot = if (allowOverride) File(context.filesDir, "content") else null
+    val opener: (String) -> InputStream = { path ->
+        val overridden = overrideRoot?.let { root ->
+            val rel = path.removePrefix("content/")
+            File(root, rel).takeIf { it.isFile }
+        }
+        overridden?.inputStream() ?: context.assets.open(path)
+    }
+    synchronized(this) {
+        bundle = ContentLoader.loadAndValidate(opener)
+        lastSourceMap = computeSourceMap(overrideRoot)
+    }
+}
+```
+
+### Source map for `/content/info`
+
+`ContentLoader` already passes a fixed list of paths through `parse()`. Reuse those paths to compute, post-load, which ones the override actually served. Simplest: have the opener record `path -> "override" | "asset"` into a `MutableMap` and stash that as `ContentRepository.lastSourceMap` after a successful load.
+
+### `RealmsApp.onCreate`
+
+```kotlin
+ContentRepository.initialize(this, allowOverride = BuildConfig.DEBUG)
+```
+
+### `ContentEndpoints.kt` (new, debug-only)
+
+```kotlin
+object ContentEndpoints {
+    fun register() {
+        DebugServer.route("GET", "/content/info") { _ ->
+            val info = ContentRepository.info()
+            HttpResponse.json(info.toJson())
+        }
+        DebugServer.route("POST", "/content/reload") { _ ->
+            val app = DebugBridge.requireActivity().application
+            try {
+                ContentRepository.initialize(app, allowOverride = true)
+                HttpResponse.json("""{"ok":true,"info":${ContentRepository.info().toJson()}}""")
+            } catch (e: ContentException) {
+                HttpResponse.error(409, "reload failed: ${e.message}")
+            }
+        }
+    }
+}
+```
+
+Wired into `DebugServer.start()` next to the other `*.register()` calls.
+
+### `ContentRepository.info()` shape
+
+```kotlin
+data class ContentInfo(
+    val schemaVersion: Int,
+    val overrideEnabled: Boolean,
+    val overrideRoot: String?,
+    val sources: Map<String, String>, // path -> "override" | "asset"
+)
+```
+
+`toJson()` lives in `ContentEndpoints.kt` (debug-only) so the production `ContentRepository` doesn't pull in JSON-emit dependencies.
+
+## What does NOT change
+
+- `assets/content/**` paths and shapes.
+- `Mutations.kt`, `Scenarios.kt`, `Spells.kt`, `Races.kt`, `Classes.kt`, `Feats.kt`, `LoreGen.kt`, `WorldEvents.kt` — all still read through `ContentRepository` getters and pick up the new bundle automatically after a reload.
+- `CONTENT_SCHEMA_VERSION` stays at `5`.
+- Release builds.
+
+## Tests
+
+| Test | Purpose |
+|---|---|
+| `HotReloadTest.override file wins over asset` | Write a temp file under `filesDir/content/world/mutations.json` with a single fake mutation. Init repo with `allowOverride=true`. Assert `mutations` returns just that fake mutation. |
+| `HotReloadTest.missing override file falls back to asset` | Override directory exists but `mutations.json` is absent. Assert `mutations` returns the bundled list. |
+| `HotReloadTest.override schema mismatch fails reload` | Override `schema-version.json` declares `99`. Assert `SchemaVersionMismatch` is raised, prior bundle remains queryable. |
+| `HotReloadTest.disabled override ignores filesDir` | Write a file under `filesDir/content/...`. Init with `allowOverride=false`. Assert bundled value wins. |
+| `HotReloadTest.info reports per-file source` | Override one file, init, assert `info().sources` shows `override` for that path and `asset` for the rest. |
+
+All under `app/src/test/kotlin/com/realmsoffate/game/data/content/HotReloadTest.kt` (Robolectric).
+
+## Manual verification (debug-bridge procedure)
+
+1. `gradle installDebug && launch && forward 8735` (standard).
+2. `curl localhost:8735/content/info` — reports `overrideEnabled: true`, all sources `asset`.
+3. Push an override:
+   `adb shell run-as com.realmsoffate.game mkdir -p files/content/world` then
+   `adb push patched/mutations.json /data/local/tmp/m.json` then
+   `adb shell run-as com.realmsoffate.game cp /data/local/tmp/m.json files/content/world/mutations.json`
+   (or use the `adb shell` techniques the project's debug-bridge already documents)
+4. `curl -X POST localhost:8735/content/reload` — `ok:true`, `sources` shows `override` for `content/world/mutations.json`.
+5. Trigger a scene that surfaces a mutation — narrator output uses the patched copy.
+
+## Acceptance
+
+- [ ] `ContentRepository.initialize(context, allowOverride: Boolean)` exists; debug build passes `BuildConfig.DEBUG`, release passes `false`.
+- [ ] Override is per-file: missing override files fall through to bundled assets without error.
+- [ ] Schema mismatch in override → `SchemaVersionMismatch`; prior bundle is preserved across a failed reload.
+- [ ] `GET /content/info` reports schema version, override enabled, override root path, per-file source map.
+- [ ] `POST /content/reload` re-runs initialize, returns the new info or a 409 with diagnostic on failure.
+- [ ] Hot-reload unit tests pass.
+- [ ] `gradle test`, `gradle assembleDebug` pass.
+- [ ] App boots; `/content/info` returns sensible JSON; manual override + reload demonstrably changes a value.
+
+## Out of scope (M7)
+
+- Deleting the M2/M3/M4/M5 facades.
+- Epic-level seeded-output parity test.


### PR DESCRIPTION
## Summary
- `ContentRepository.initialize(context, allowOverride)` now layers `<filesDir>/content/<rel-path>` over the bundled APK assets when `allowOverride = true` (debug builds only). Per-file overlay — drop a single JSON without supplying the rest.
- Reload is **atomic**: if the new bundle fails to parse / validate, the prior bundle is left live and the underlying `ContentException` propagates.
- New `ContentInfo` records schema version, override status, and a per-file source map (`"asset"` | `"override"`).
- New debug-only endpoints in `ContentEndpoints.kt`:
  - `GET /content/info` — snapshot of load state.
  - `POST /content/reload` — re-runs `initialize(allowOverride=true)`. Returns 200 with new info, or **409 with diagnostic** on failure.
- `RealmsApp.onCreate` passes `BuildConfig.DEBUG` so release builds are unaffected.

Schema version unchanged (still 5) — this PR ships only code.

Builds on M1+M2/M3/M4/M5a/M5b (#24). Design at `docs/superpowers/specs/2026-05-01-phase6-json-content-m6-design.md`.

## Test plan
- [x] `gradle test` — passing, including new `HotReloadTest` covering: override-wins, missing-override-falls-through, schema-mismatch-preserves-prior-bundle, disabled-override-ignores-filesDir, info-reports-per-file-source
- [x] `gradle assembleDebug`
- [x] Deployed to `emulator-5554`; P0 (`/state` HTTP 200) green
- [x] **Manual hot-reload verification:**
  - `GET /content/info` reports `overrideEnabled: true`, all 16 paths `asset`
  - Pushed override mutations.json via `adb shell run-as`, called `POST /content/reload`, response shows `mutations source = override`
  - Pushed bad schema-version.json (`version: 999`), reload returned **HTTP 409** with `Content schema version mismatch: expected 5, got 999`, app stayed responsive on `/state`
  - Cleaned up overrides, reload restored `override count = 0`

Refs #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)