### PR TITLE
feat(phase7-updater): M1 — SemVer comparator (#28)

### DIFF
--- a/app/src/main/kotlin/com/realmsoffate/game/data/updater/SemVer.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/data/updater/SemVer.kt
@@ -1,0 +1,68 @@
+package com.realmsoffate.game.data.updater
+
+/**
+ * Minimal semver per https://semver.org §11. Build metadata (`+...`) is parsed
+ * but ignored for ordering. Prerelease identifiers are stored as a list and
+ * compared per-identifier (numeric vs alphanumeric rules).
+ */
+data class SemVer(
+    val major: Int,
+    val minor: Int,
+    val patch: Int,
+    val prerelease: List<String>
+) : Comparable<SemVer> {
+
+    override fun compareTo(other: SemVer): Int {
+        if (major != other.major) return major.compareTo(other.major)
+        if (minor != other.minor) return minor.compareTo(other.minor)
+        if (patch != other.patch) return patch.compareTo(other.patch)
+        // §11.3: a release version > any prerelease at same MMP
+        val a = prerelease
+        val b = other.prerelease
+        if (a.isEmpty() && b.isEmpty()) return 0
+        if (a.isEmpty()) return 1
+        if (b.isEmpty()) return -1
+        // §11.4: per-identifier compare
+        val len = minOf(a.size, b.size)
+        for (i in 0 until len) {
+            val c = compareIdentifiers(a[i], b[i])
+            if (c != 0) return c
+        }
+        // §11.4.4: longer wins when prefix matches
+        return a.size.compareTo(b.size)
+    }
+
+    private fun compareIdentifiers(a: String, b: String): Int {
+        val ai = a.toIntOrNull()
+        val bi = b.toIntOrNull()
+        return when {
+            ai != null && bi != null -> ai.compareTo(bi)
+            ai != null && bi == null -> -1   // numeric < alphanumeric per §11.4.3
+            ai == null && bi != null -> 1
+            else -> a.compareTo(b)
+        }
+    }
+
+    companion object {
+        private val CORE = Regex("""(\d+)\.(\d+)\.(\d+)""")
+
+        fun parse(raw: String): SemVer {
+            val noV = raw.removePrefix("v").removePrefix("V")
+            val noBuild = noV.substringBefore('+')
+            val core = noBuild.substringBefore('-')
+            val pre = noBuild.substringAfter('-', missingDelimiterValue = "")
+            val m = CORE.matchEntire(core)
+                ?: throw IllegalArgumentException("Bad semver: '$raw'")
+            val parts = if (pre.isEmpty()) emptyList() else pre.split('.')
+            for (p in parts) {
+                if (p.isEmpty()) throw IllegalArgumentException("Empty prerelease segment in '$raw'")
+            }
+            return SemVer(
+                major = m.groupValues[1].toInt(),
+                minor = m.groupValues[2].toInt(),
+                patch = m.groupValues[3].toInt(),
+                prerelease = parts
+            )
+        }
+    }
+}

--- a/app/src/test/kotlin/com/realmsoffate/game/data/updater/SemVerTest.kt
+++ b/app/src/test/kotlin/com/realmsoffate/game/data/updater/SemVerTest.kt
@@ -48,4 +48,59 @@ class SemVerTest {
         assertThrows(IllegalArgumentException::class.java) { SemVer.parse("1.2") }
         assertThrows(IllegalArgumentException::class.java) { SemVer.parse("1.2.x") }
     }
+
+    @Test fun `1_2_3 lt 1_2_4`() {
+        assertTrue(SemVer.parse("1.2.3") < SemVer.parse("1.2.4"))
+    }
+
+    @Test fun `1_2_3 lt 1_3_0`() {
+        assertTrue(SemVer.parse("1.2.3") < SemVer.parse("1.3.0"))
+    }
+
+    @Test fun `1_9_9 lt 2_0_0`() {
+        assertTrue(SemVer.parse("1.9.9") < SemVer.parse("2.0.0"))
+    }
+
+    @Test fun `prerelease lt release at same MMP`() {
+        assertTrue(SemVer.parse("1.0.0-rc.1") < SemVer.parse("1.0.0"))
+        assertTrue(SemVer.parse("0.1.0-alpha.1") < SemVer.parse("0.1.0"))
+    }
+
+    @Test fun `alpha lt beta`() {
+        assertTrue(SemVer.parse("1.0.0-alpha") < SemVer.parse("1.0.0-beta"))
+        assertTrue(SemVer.parse("1.0.0-alpha.1") < SemVer.parse("1.0.0-beta.1"))
+    }
+
+    @Test fun `alpha_1 lt alpha_2`() {
+        assertTrue(SemVer.parse("0.1.0-alpha.1") < SemVer.parse("0.1.0-alpha.2"))
+    }
+
+    @Test fun `alpha_2 lt alpha_10 numerically`() {
+        assertTrue(SemVer.parse("0.1.0-alpha.2") < SemVer.parse("0.1.0-alpha.10"))
+    }
+
+    @Test fun `numeric lt alphanumeric per spec`() {
+        // §11.4.3: numeric identifiers always have lower precedence than alphanumeric
+        assertTrue(SemVer.parse("1.0.0-1") < SemVer.parse("1.0.0-alpha"))
+    }
+
+    @Test fun `longer prerelease wins when prefix matches`() {
+        // §11.4.4
+        assertTrue(SemVer.parse("1.0.0-alpha") < SemVer.parse("1.0.0-alpha.1"))
+    }
+
+    @Test fun `equal prereleases compare equal`() {
+        assertEquals(0, SemVer.parse("1.0.0-rc.1").compareTo(SemVer.parse("1.0.0-rc.1")))
+    }
+
+    @Test fun `comparator is reflexive across version transitions`() {
+        val versions = listOf(
+            "0.1.0-alpha.1", "0.1.0-alpha.2", "0.1.0-alpha.10",
+            "0.1.0-beta.1", "0.1.0-rc.1", "0.1.0",
+            "0.1.1", "0.2.0", "1.0.0-rc.1", "1.0.0"
+        ).map { SemVer.parse(it) }
+        for (i in 0 until versions.size - 1) {
+            assertTrue("${versions[i]} should be < ${versions[i + 1]}", versions[i] < versions[i + 1])
+        }
+    }
 }

--- a/app/src/test/kotlin/com/realmsoffate/game/data/updater/SemVerTest.kt
+++ b/app/src/test/kotlin/com/realmsoffate/game/data/updater/SemVerTest.kt
@@ -1,0 +1,51 @@
+package com.realmsoffate.game.data.updater
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SemVerTest {
+    @Test fun `parses MAJOR_MINOR_PATCH`() {
+        val v = SemVer.parse("1.2.3")
+        assertEquals(1, v.major)
+        assertEquals(2, v.minor)
+        assertEquals(3, v.patch)
+        assertTrue(v.prerelease.isEmpty())
+    }
+
+    @Test fun `parses with prerelease`() {
+        val v = SemVer.parse("0.1.0-alpha.1")
+        assertEquals(0, v.major)
+        assertEquals(1, v.minor)
+        assertEquals(0, v.patch)
+        assertEquals(listOf("alpha", "1"), v.prerelease)
+    }
+
+    @Test fun `tolerates leading v`() {
+        val v = SemVer.parse("v0.1.0-alpha.1")
+        assertEquals(0, v.major)
+    }
+
+    @Test fun `strips build metadata`() {
+        val v = SemVer.parse("1.2.3+abc.def")
+        assertEquals(1, v.major)
+        assertTrue(v.prerelease.isEmpty())
+    }
+
+    @Test fun `equality on same version`() {
+        assertEquals(SemVer.parse("1.2.3"), SemVer.parse("1.2.3"))
+        assertEquals(SemVer.parse("1.2.3-alpha.1"), SemVer.parse("v1.2.3-alpha.1"))
+    }
+
+    @Test fun `inequality across patch`() {
+        assertNotEquals(SemVer.parse("1.2.3"), SemVer.parse("1.2.4"))
+    }
+
+    @Test fun `malformed throws`() {
+        assertThrows(IllegalArgumentException::class.java) { SemVer.parse("not-a-version") }
+        assertThrows(IllegalArgumentException::class.java) { SemVer.parse("1.2") }
+        assertThrows(IllegalArgumentException::class.java) { SemVer.parse("1.2.x") }
+    }
+}


### PR DESCRIPTION
## Summary
- Pure Kotlin semver parser + comparator per [semver.org §11](https://semver.org).
- 18 unit tests covering parse, equality, ordering across MAJOR/MINOR/PATCH, prerelease vs release, alpha/beta/rc, numeric/alphanumeric identifier rules.
- No Android deps; foundation for the auto-update system (#28).

Spec: [`docs/superpowers/specs/2026-05-01-phase7-auto-update-system-design.md`](docs/superpowers/specs/2026-05-01-phase7-auto-update-system-design.md)

## Test plan
- [x] `gradle :app:testDebugUnitTest --tests "com.realmsoffate.game.data.updater.SemVerTest"` passes locally (18/18)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)