### PR TITLE
feat(phase7-updater): M3 — UpdatePrefs + State + Channel (#28)

### DIFF
--- a/app/src/main/kotlin/com/realmsoffate/game/data/updater/UpdateChannel.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/data/updater/UpdateChannel.kt
@@ -1,0 +1,24 @@
+package com.realmsoffate.game.data.updater
+
+enum class UpdateChannel {
+    /** Only releases with `prerelease = false` are surfaced. */
+    STABLE_ONLY,
+    /** All releases including alphas/betas/RCs are surfaced. */
+    INCLUDE_PRERELEASES;
+
+    fun accepts(release: ReleaseInfo): Boolean = when (this) {
+        STABLE_ONLY -> !release.isPrerelease
+        INCLUDE_PRERELEASES -> true
+    }
+
+    companion object {
+        /** Default for pre-1.0 era. Flip to STABLE_ONLY at 1.0.0 ship time. */
+        val DEFAULT: UpdateChannel = INCLUDE_PRERELEASES
+
+        fun fromString(value: String?): UpdateChannel = when (value) {
+            STABLE_ONLY.name -> STABLE_ONLY
+            INCLUDE_PRERELEASES.name -> INCLUDE_PRERELEASES
+            else -> DEFAULT
+        }
+    }
+}

--- a/app/src/main/kotlin/com/realmsoffate/game/data/updater/UpdatePrefs.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/data/updater/UpdatePrefs.kt
@@ -1,0 +1,74 @@
+package com.realmsoffate.game.data.updater
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private val Context.updaterDataStore by preferencesDataStore(name = "realms_updater")
+
+/**
+ * DataStore-backed preferences for the auto-update system. Mirrors the
+ * CheatsStore pattern (Flow read, suspend write). Dismissed versions are
+ * bounded to 10 most-recent to prevent unbounded growth.
+ */
+class UpdatePrefs(private val context: Context) {
+
+    private val keyChannel = stringPreferencesKey("channel")
+    private val keyLastCheckedAt = longPreferencesKey("last_checked_at")
+    private val keyDismissedVersions = stringSetPreferencesKey("dismissed_versions")
+    private val keyDismissedOrder = stringPreferencesKey("dismissed_order")
+    private val keyLastKnownTag = stringPreferencesKey("last_known_release_tag")
+
+    val channel: Flow<UpdateChannel> = context.updaterDataStore.data
+        .map { UpdateChannel.fromString(it[keyChannel]) }
+
+    val lastCheckedAt: Flow<Long?> = context.updaterDataStore.data
+        .map { it[keyLastCheckedAt] }
+
+    val dismissedVersions: Flow<Set<String>> = context.updaterDataStore.data
+        .map { it[keyDismissedVersions] ?: emptySet() }
+
+    val lastKnownReleaseTag: Flow<String?> = context.updaterDataStore.data
+        .map { it[keyLastKnownTag] }
+
+    suspend fun setChannel(channel: UpdateChannel) {
+        context.updaterDataStore.edit { it[keyChannel] = channel.name }
+    }
+
+    suspend fun setLastCheckedAt(epochMillis: Long) {
+        context.updaterDataStore.edit { it[keyLastCheckedAt] = epochMillis }
+    }
+
+    suspend fun setLastKnownReleaseTag(tag: String?) {
+        context.updaterDataStore.edit {
+            if (tag == null) it.remove(keyLastKnownTag) else it[keyLastKnownTag] = tag
+        }
+    }
+
+    /** Dismiss [tag] from banner display. Maintains FIFO bound of 10 entries. */
+    suspend fun dismissVersion(tag: String) {
+        context.updaterDataStore.edit { mutable ->
+            val orderRaw = mutable[keyDismissedOrder] ?: ""
+            val order = if (orderRaw.isEmpty()) mutableListOf() else orderRaw.split('|').toMutableList()
+            order.remove(tag)
+            order.add(tag)
+            while (order.size > MAX_DISMISSED) order.removeAt(0)
+            mutable[keyDismissedOrder] = order.joinToString("|")
+            mutable[keyDismissedVersions] = order.toSet()
+        }
+    }
+
+    /** TEST ONLY: clear all keys. */
+    suspend fun clearForTest() {
+        context.updaterDataStore.edit { it.clear() }
+    }
+
+    companion object {
+        const val MAX_DISMISSED = 10
+    }
+}

--- a/app/src/main/kotlin/com/realmsoffate/game/data/updater/UpdateState.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/data/updater/UpdateState.kt
@@ -1,0 +1,19 @@
+package com.realmsoffate.game.data.updater
+
+import java.io.File
+
+/**
+ * State machine consumed by the UI. UpdateRepository emits transitions through
+ * a single MutableStateFlow. Note: Available -> Downloading -> ReadyToInstall
+ * is the only valid forward path; cancellations and errors revert to earlier
+ * states (or Idle / UpToDate as appropriate).
+ */
+sealed class UpdateState {
+    object Idle : UpdateState()
+    object Checking : UpdateState()
+    object UpToDate : UpdateState()
+    data class Available(val release: ReleaseInfo) : UpdateState()
+    data class Downloading(val release: ReleaseInfo, val progress: Int) : UpdateState()
+    data class ReadyToInstall(val release: ReleaseInfo, val file: File) : UpdateState()
+    data class Error(val reason: String, val recoverable: Boolean) : UpdateState()
+}

--- a/app/src/test/kotlin/com/realmsoffate/game/data/updater/UpdatePrefsTest.kt
+++ b/app/src/test/kotlin/com/realmsoffate/game/data/updater/UpdatePrefsTest.kt
@@ -1,0 +1,57 @@
+package com.realmsoffate.game.data.updater
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class UpdatePrefsTest {
+    private val ctx: Context = ApplicationProvider.getApplicationContext()
+    private val prefs = UpdatePrefs(ctx)
+
+    @After fun tearDown() = runTest { prefs.clearForTest() }
+
+    @Test fun `default channel is INCLUDE_PRERELEASES`() = runTest {
+        assertEquals(UpdateChannel.INCLUDE_PRERELEASES, prefs.channel.first())
+    }
+
+    @Test fun `setChannel persists`() = runTest {
+        prefs.setChannel(UpdateChannel.STABLE_ONLY)
+        assertEquals(UpdateChannel.STABLE_ONLY, prefs.channel.first())
+    }
+
+    @Test fun `lastCheckedAt defaults to null`() = runTest {
+        assertNull(prefs.lastCheckedAt.first())
+    }
+
+    @Test fun `setLastCheckedAt persists`() = runTest {
+        prefs.setLastCheckedAt(1_700_000_000_000L)
+        assertEquals(1_700_000_000_000L, prefs.lastCheckedAt.first())
+    }
+
+    @Test fun `dismissedVersions starts empty`() = runTest {
+        assertTrue(prefs.dismissedVersions.first().isEmpty())
+    }
+
+    @Test fun `dismissVersion adds tag`() = runTest {
+        prefs.dismissVersion("v0.2.0")
+        assertEquals(setOf("v0.2.0"), prefs.dismissedVersions.first())
+    }
+
+    @Test fun `dismissedVersions bounded to 10 most recent`() = runTest {
+        for (i in 1..15) prefs.dismissVersion("v0.0.$i")
+        val set = prefs.dismissedVersions.first()
+        assertEquals(10, set.size)
+        assertFalse("oldest should have been pruned", set.contains("v0.0.1"))
+        assertTrue("newest must be present", set.contains("v0.0.15"))
+    }
+}


### PR DESCRIPTION
## Summary
- `UpdateChannel` enum with `accepts(release)` predicate, defaulting to `INCLUDE_PRERELEASES` for the pre-1.0 era.
- `UpdateState` sealed class — Idle / Checking / UpToDate / Available / Downloading / ReadyToInstall / Error.
- `UpdatePrefs` DataStore wrapper mirroring `CheatsStore`. Bounded dismissed-versions list (FIFO, max 10).

Spec: [`docs/superpowers/specs/2026-05-01-phase7-auto-update-system-design.md`](docs/superpowers/specs/2026-05-01-phase7-auto-update-system-design.md)

## Test plan
- [x] `gradle :app:testDebugUnitTest --tests "com.realmsoffate.game.data.updater.UpdatePrefsTest"` passes locally (7/7)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)