### PR TITLE
feat(phase7-updater): M4 — UpdateRepository check path (#28)

### DIFF
--- a/app/src/main/kotlin/com/realmsoffate/game/data/updater/UpdateRepository.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/data/updater/UpdateRepository.kt
@@ -99,12 +99,11 @@ class UpdateRepository(
         scope.launch { prefs.dismissVersion(tag) }
     }
 
-    fun setChannel(channel: UpdateChannel) {
+    fun setChannel(channel: UpdateChannel): Job =
         scope.launch {
             prefs.setChannel(channel)
-            check(force = true)
+            check(force = true).join()
         }
-    }
 
     companion object {
         /** 6 hours. */

--- a/app/src/main/kotlin/com/realmsoffate/game/data/updater/UpdateRepository.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/data/updater/UpdateRepository.kt
@@ -1,0 +1,113 @@
+package com.realmsoffate.game.data.updater
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+
+/**
+ * Anything that can return a list of releases. Production: GitHubReleasesClient.
+ * Tests: in-memory fake. Lets the repository remain agnostic to OkHttp.
+ */
+interface ReleasesSource {
+    suspend fun fetchReleases(): GitHubReleasesClient.Result
+}
+
+/** Production adapter so the existing GitHubReleasesClient implements ReleasesSource. */
+class GitHubReleasesSource(private val delegate: GitHubReleasesClient) : ReleasesSource {
+    override suspend fun fetchReleases() = delegate.fetchReleases()
+}
+
+/**
+ * Process-level singleton (initialized in RealmsApp). Reduces network responses
+ * + user actions into [UpdateState]. Cache is in-memory (TTL on lastCheckedAt);
+ * channel + dismissals + last-known-tag persist in [UpdatePrefs].
+ */
+class UpdateRepository(
+    private val currentVersionName: String,
+    private val client: ReleasesSource,
+    private val prefs: UpdatePrefs,
+    private val clock: () -> Long = System::currentTimeMillis,
+    private val cacheTtlMs: Long = DEFAULT_CACHE_TTL_MS,
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+) {
+    private val _state = MutableStateFlow<UpdateState>(UpdateState.Idle)
+    val state: StateFlow<UpdateState> = _state.asStateFlow()
+
+    private var checkJob: Job? = null
+
+    /**
+     * Trigger a release check. If [force] is false and the cache is fresh (<TTL),
+     * no-op except for re-emitting the current state. Cancels any in-flight check.
+     * Returns the launched [Job] so callers (notably tests) can await completion.
+     */
+    fun check(force: Boolean = false): Job {
+        checkJob?.cancel()
+        val job = scope.launch {
+            if (!force) {
+                val last = prefs.lastCheckedAt.first()
+                if (last != null && clock() - last < cacheTtlMs) {
+                    return@launch
+                }
+            }
+            _state.value = UpdateState.Checking
+            val channel = prefs.channel.first()
+            when (val r = client.fetchReleases()) {
+                is GitHubReleasesClient.Result.Ok -> {
+                    prefs.setLastCheckedAt(clock())
+                    val current = runCatching { SemVer.parse(currentVersionName) }.getOrNull()
+                        ?: run {
+                            _state.value = UpdateState.Error("Bad app version", recoverable = false)
+                            return@launch
+                        }
+                    val candidate = r.releases
+                        .filter(channel::accepts)
+                        .filter { it.version > current }
+                        .maxByOrNull { it.version }
+                    _state.value = when {
+                        candidate == null -> UpdateState.UpToDate
+                        else -> {
+                            prefs.setLastKnownReleaseTag(candidate.tag)
+                            UpdateState.Available(candidate)
+                        }
+                    }
+                }
+                is GitHubReleasesClient.Result.NetworkError ->
+                    _state.value = UpdateState.Error("No connection", recoverable = true)
+                is GitHubReleasesClient.Result.RateLimited ->
+                    _state.value = UpdateState.Error("Rate-limited, try again later", recoverable = true)
+                is GitHubReleasesClient.Result.HttpError ->
+                    _state.value = UpdateState.Error("Couldn't reach GitHub (${r.code})", recoverable = true)
+                is GitHubReleasesClient.Result.ParseError ->
+                    _state.value = UpdateState.Error("Couldn't parse release", recoverable = false)
+            }
+        }
+        checkJob = job
+        return job
+    }
+
+    /** UI helper: should the title-screen banner show for this release? */
+    suspend fun bannerVisibleFor(release: ReleaseInfo): Boolean =
+        release.tag !in prefs.dismissedVersions.first()
+
+    fun dismissBannerForVersion(tag: String) {
+        scope.launch { prefs.dismissVersion(tag) }
+    }
+
+    fun setChannel(channel: UpdateChannel) {
+        scope.launch {
+            prefs.setChannel(channel)
+            check(force = true)
+        }
+    }
+
+    companion object {
+        /** 6 hours. */
+        const val DEFAULT_CACHE_TTL_MS: Long = 6L * 60L * 60L * 1000L
+    }
+}

--- a/app/src/test/kotlin/com/realmsoffate/game/data/updater/UpdateRepositoryTest.kt
+++ b/app/src/test/kotlin/com/realmsoffate/game/data/updater/UpdateRepositoryTest.kt
@@ -106,4 +106,100 @@ class UpdateRepositoryTest {
         repo.check(force = false).join()
         assertEquals(nowMs, prefs.lastCheckedAt.first())
     }
+
+    @Test fun `STABLE_ONLY excludes prereleases`() = runTest {
+        val repo = newRepo()
+        prefs.setChannel(UpdateChannel.STABLE_ONLY)
+        client.nextResult = GitHubReleasesClient.Result.Ok(listOf(
+            release("v0.2.0-alpha.1", prerelease = true)
+        ))
+        repo.check(force = true).join()
+        assertEquals(UpdateState.UpToDate, repo.state.value)
+    }
+
+    @Test fun `INCLUDE_PRERELEASES surfaces alpha`() = runTest {
+        val repo = newRepo()
+        prefs.setChannel(UpdateChannel.INCLUDE_PRERELEASES)
+        client.nextResult = GitHubReleasesClient.Result.Ok(listOf(
+            release("v0.2.0-alpha.1", prerelease = true, assetName = "realms-v0.2.0-alpha.1-release.apk")
+        ))
+        repo.check(force = true).join()
+        assertTrue(repo.state.value is UpdateState.Available)
+    }
+
+    @Test fun `dismissed version still becomes Available state`() = runTest {
+        val repo = newRepo()
+        client.nextResult = GitHubReleasesClient.Result.Ok(listOf(
+            release("v0.2.0", assetName = "realms-v0.2.0-release.apk")
+        ))
+        prefs.dismissVersion("v0.2.0")
+        repo.check(force = true).join()
+        val state = repo.state.value
+        assertTrue(state is UpdateState.Available)
+        assertEquals(false, repo.bannerVisibleFor((state as UpdateState.Available).release))
+    }
+
+    @Test fun `non-dismissed version banner visible`() = runTest {
+        val repo = newRepo()
+        client.nextResult = GitHubReleasesClient.Result.Ok(listOf(
+            release("v0.2.0", assetName = "realms-v0.2.0-release.apk")
+        ))
+        repo.check(force = true).join()
+        val state = repo.state.value as UpdateState.Available
+        assertEquals(true, repo.bannerVisibleFor(state.release))
+    }
+
+    @Test fun `network error becomes recoverable Error`() = runTest {
+        val repo = newRepo()
+        client.nextResult = GitHubReleasesClient.Result.NetworkError("no route")
+        repo.check(force = true).join()
+        val state = repo.state.value
+        assertTrue(state is UpdateState.Error)
+        assertTrue((state as UpdateState.Error).recoverable)
+    }
+
+    @Test fun `parse error is non-recoverable`() = runTest {
+        val repo = newRepo()
+        client.nextResult = GitHubReleasesClient.Result.ParseError("bad json")
+        repo.check(force = true).join()
+        val state = repo.state.value as UpdateState.Error
+        assertEquals(false, state.recoverable)
+    }
+
+    @Test fun `rate limited is recoverable`() = runTest {
+        val repo = newRepo()
+        client.nextResult = GitHubReleasesClient.Result.RateLimited(null)
+        repo.check(force = true).join()
+        val state = repo.state.value as UpdateState.Error
+        assertTrue(state.recoverable)
+    }
+
+    @Test fun `picks highest semver when multiple newer`() = runTest {
+        val repo = newRepo()
+        client.nextResult = GitHubReleasesClient.Result.Ok(listOf(
+            release("v0.2.0-alpha.1", prerelease = true, assetName = "realms-v0.2.0-alpha.1-release.apk"),
+            release("v0.2.0-alpha.10", prerelease = true, assetName = "realms-v0.2.0-alpha.10-release.apk"),
+            release("v0.1.5", assetName = "realms-v0.1.5-release.apk")
+        ))
+        repo.check(force = true).join()
+        val state = repo.state.value as UpdateState.Available
+        assertEquals("v0.2.0-alpha.10", state.release.tag)
+    }
+
+    @Test fun `lastKnownReleaseTag persists across checks`() = runTest {
+        val repo = newRepo()
+        client.nextResult = GitHubReleasesClient.Result.Ok(listOf(
+            release("v0.2.0", assetName = "realms-v0.2.0-release.apk")
+        ))
+        repo.check(force = true).join()
+        assertEquals("v0.2.0", prefs.lastKnownReleaseTag.first())
+    }
+
+    @Test fun `setChannel triggers re-check`() = runTest {
+        val repo = newRepo()
+        client.nextResult = GitHubReleasesClient.Result.Ok(emptyList())
+        repo.setChannel(UpdateChannel.STABLE_ONLY).join()
+        assertEquals(UpdateChannel.STABLE_ONLY, prefs.channel.first())
+        assertEquals(1, client.calls)
+    }
 }

--- a/app/src/test/kotlin/com/realmsoffate/game/data/updater/UpdateRepositoryTest.kt
+++ b/app/src/test/kotlin/com/realmsoffate/game/data/updater/UpdateRepositoryTest.kt
@@ -1,0 +1,109 @@
+package com.realmsoffate.game.data.updater
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+private class FakeClient(
+    var nextResult: GitHubReleasesClient.Result = GitHubReleasesClient.Result.Ok(emptyList())
+) : ReleasesSource {
+    var calls = 0
+    override suspend fun fetchReleases(): GitHubReleasesClient.Result {
+        calls++
+        return nextResult
+    }
+}
+
+private fun release(tag: String, prerelease: Boolean = false, assetName: String? = null): ReleaseInfo =
+    ReleaseInfo(
+        tag = tag,
+        name = tag,
+        version = SemVer.parse(tag),
+        isPrerelease = prerelease,
+        body = "Notes for $tag",
+        assets = if (assetName != null)
+            listOf(ReleaseInfo.Asset(assetName, "https://example.test/$assetName", 1024))
+        else emptyList()
+    )
+
+@RunWith(RobolectricTestRunner::class)
+class UpdateRepositoryTest {
+
+    private val ctx: Context = ApplicationProvider.getApplicationContext()
+    private val prefs = UpdatePrefs(ctx)
+    private val client = FakeClient()
+    private var nowMs = 1_700_000_000_000L
+    private val clock = { nowMs }
+
+    private fun newRepo(versionName: String = "0.1.0-alpha.1"): UpdateRepository =
+        UpdateRepository(
+            currentVersionName = versionName,
+            client = client,
+            prefs = prefs,
+            clock = clock,
+            cacheTtlMs = UpdateRepository.DEFAULT_CACHE_TTL_MS
+        )
+
+    @After fun tearDown() = runTest { prefs.clearForTest() }
+
+    @Test fun `idle on construction`() = runTest {
+        val repo = newRepo()
+        assertEquals(UpdateState.Idle, repo.state.value)
+    }
+
+    @Test fun `check with no newer release leaves UpToDate`() = runTest {
+        val repo = newRepo()
+        client.nextResult = GitHubReleasesClient.Result.Ok(listOf(release("v0.1.0-alpha.1")))
+        repo.check(force = false).join()
+        assertEquals(UpdateState.UpToDate, repo.state.value)
+        assertEquals(1, client.calls)
+    }
+
+    @Test fun `check with newer release becomes Available`() = runTest {
+        val repo = newRepo()
+        client.nextResult = GitHubReleasesClient.Result.Ok(listOf(release("v0.2.0", assetName = "realms-v0.2.0-release.apk")))
+        repo.check(force = false).join()
+        val s = repo.state.value
+        assertTrue("expected Available, was $s", s is UpdateState.Available)
+        assertEquals("v0.2.0", (s as UpdateState.Available).release.tag)
+    }
+
+    @Test fun `cache hit short-circuits within TTL`() = runTest {
+        val repo = newRepo()
+        client.nextResult = GitHubReleasesClient.Result.Ok(listOf(release("v0.1.0-alpha.1")))
+        repo.check(force = false).join()
+        repo.check(force = false).join()
+        assertEquals("client should be called once when within cache window", 1, client.calls)
+    }
+
+    @Test fun `force bypasses cache`() = runTest {
+        val repo = newRepo()
+        client.nextResult = GitHubReleasesClient.Result.Ok(listOf(release("v0.1.0-alpha.1")))
+        repo.check(force = false).join()
+        repo.check(force = true).join()
+        assertEquals(2, client.calls)
+    }
+
+    @Test fun `cache expired after TTL passes`() = runTest {
+        val repo = newRepo()
+        client.nextResult = GitHubReleasesClient.Result.Ok(listOf(release("v0.1.0-alpha.1")))
+        repo.check(force = false).join()
+        nowMs += UpdateRepository.DEFAULT_CACHE_TTL_MS + 1
+        repo.check(force = false).join()
+        assertEquals(2, client.calls)
+    }
+
+    @Test fun `lastCheckedAt persists`() = runTest {
+        val repo = newRepo()
+        client.nextResult = GitHubReleasesClient.Result.Ok(listOf(release("v0.1.0-alpha.1")))
+        repo.check(force = false).join()
+        assertEquals(nowMs, prefs.lastCheckedAt.first())
+    }
+}


### PR DESCRIPTION
## Summary
- `UpdateRepository` reduces release responses + user actions into `UpdateState`.
- 6h cache; `force = true` bypasses; channel filter via `UpdateChannel.accepts`; dismissals don't gate state but feed `bannerVisibleFor()`.
- All five `GitHubReleasesClient.Result` variants map to deterministic `UpdateState.Error(reason, recoverable)` or `UpToDate`/`Available`.
- `check()` and `setChannel()` return their `Job` so tests can `join()` rather than fight the repo's independent `Dispatchers.Default` scope (deviation from the plan, which used `advanceUntilIdle()` — that doesn't drive a non-test scheduler and the original pattern was unsound).
- 17 Robolectric unit tests via a `ReleasesSource` fake (no real network).
- Download/install paths land in M5a/M5b.

Spec: [`docs/superpowers/specs/2026-05-01-phase7-auto-update-system-design.md`](docs/superpowers/specs/2026-05-01-phase7-auto-update-system-design.md)

## Test plan
- [x] `gradle :app:testDebugUnitTest --tests "com.realmsoffate.game.data.updater.*"` passes locally (51/51 incl. M1–M3)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)