### PR TITLE
feat(phase7-updater): M5a — APK download (#28)

### DIFF
--- a/app/src/main/kotlin/com/realmsoffate/game/data/updater/ApkDownloader.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/data/updater/ApkDownloader.kt
@@ -1,0 +1,91 @@
+package com.realmsoffate.game.data.updater
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.isActive
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.File
+import java.io.IOException
+
+/** Test seam — production impl is [ApkDownloader]. */
+interface ApkDownloaderLike {
+    fun download(downloadUrl: String, filename: String, expectedSize: Long): Flow<ApkDownloader.Progress>
+}
+
+/**
+ * Streams an APK from [downloadUrl] into [cacheDir]/<filename>, emitting
+ * progress as a Flow. Terminal events are [Progress.Done] or [Progress.Failed].
+ *
+ * Cancels cleanly when the collecting coroutine is cancelled — partial file
+ * is deleted on cancellation or failure.
+ */
+class ApkDownloader(
+    private val httpClient: OkHttpClient,
+    private val cacheDir: File
+) : ApkDownloaderLike {
+    sealed class Progress {
+        data class Streaming(val bytesRead: Long, val totalBytes: Long, val percent: Int) : Progress()
+        data class Done(val file: File) : Progress()
+        data class Failed(val reason: String) : Progress()
+    }
+
+    override fun download(downloadUrl: String, filename: String, expectedSize: Long): Flow<Progress> = flow {
+        cacheDir.mkdirs()
+        val outFile = File(cacheDir, filename)
+        if (outFile.exists()) outFile.delete()
+        val request = Request.Builder().url(downloadUrl).get().build()
+        val response = try {
+            httpClient.newCall(request).execute()
+        } catch (e: IOException) {
+            emit(Progress.Failed("Network: ${e.message}"))
+            return@flow
+        }
+        try {
+            response.use { resp ->
+                if (!resp.isSuccessful) {
+                    emit(Progress.Failed("HTTP ${resp.code}"))
+                    outFile.delete()
+                    return@flow
+                }
+                val body = resp.body ?: run {
+                    emit(Progress.Failed("Empty body"))
+                    return@flow
+                }
+                val total = if (expectedSize > 0) expectedSize else (body.contentLength().takeIf { it > 0 } ?: -1L)
+                var read = 0L
+                outFile.outputStream().use { out ->
+                    body.byteStream().use { input ->
+                        val buf = ByteArray(64 * 1024)
+                        var lastEmittedPct = -1
+                        while (currentCoroutineContext().isActive) {
+                            val n = input.read(buf)
+                            if (n <= 0) break
+                            out.write(buf, 0, n)
+                            read += n
+                            if (total > 0) {
+                                val pct = ((read * 100L) / total).toInt().coerceIn(0, 100)
+                                if (pct != lastEmittedPct) {
+                                    emit(Progress.Streaming(read, total, pct))
+                                    lastEmittedPct = pct
+                                }
+                            }
+                        }
+                    }
+                }
+                if (expectedSize > 0 && read != expectedSize) {
+                    outFile.delete()
+                    emit(Progress.Failed("Download corrupt — size $read != expected $expectedSize"))
+                    return@flow
+                }
+                emit(Progress.Done(outFile))
+            }
+        } catch (e: IOException) {
+            outFile.delete()
+            emit(Progress.Failed("Network: ${e.message}"))
+        }
+    }.flowOn(Dispatchers.IO)
+}

--- a/app/src/main/kotlin/com/realmsoffate/game/data/updater/UpdateRepository.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/data/updater/UpdateRepository.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
@@ -35,6 +36,7 @@ class UpdateRepository(
     private val clock: () -> Long = System::currentTimeMillis,
     private val cacheTtlMs: Long = DEFAULT_CACHE_TTL_MS,
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+    private val downloader: ApkDownloaderLike? = null,
 ) {
     private val _state = MutableStateFlow<UpdateState>(UpdateState.Idle)
     val state: StateFlow<UpdateState> = _state.asStateFlow()
@@ -104,6 +106,46 @@ class UpdateRepository(
             prefs.setChannel(channel)
             check(force = true).join()
         }
+
+    private var downloadJob: Job? = null
+
+    fun startDownload(release: ReleaseInfo): Job {
+        val dl = downloader
+        if (dl == null) {
+            _state.value = UpdateState.Error("No downloader wired", recoverable = false)
+            return scope.launch { /* no-op */ }
+        }
+        val asset = release.realmsApkAsset()
+        if (asset == null) {
+            _state.value = UpdateState.Error("Release missing APK", recoverable = false)
+            return scope.launch { /* no-op */ }
+        }
+        downloadJob?.cancel()
+        val job = scope.launch {
+            _state.value = UpdateState.Downloading(release, progress = 0)
+            dl.download(asset.downloadUrl, "realms-${release.tag.removePrefix("v")}.apk", asset.size)
+                .collect { p ->
+                    when (p) {
+                        is ApkDownloader.Progress.Streaming ->
+                            _state.value = UpdateState.Downloading(release, progress = p.percent)
+                        is ApkDownloader.Progress.Done ->
+                            _state.value = UpdateState.ReadyToInstall(release, p.file)
+                        is ApkDownloader.Progress.Failed ->
+                            _state.value = UpdateState.Available(release)
+                    }
+                }
+        }
+        downloadJob = job
+        return job
+    }
+
+    fun cancelDownload() {
+        val current = _state.value
+        downloadJob?.cancel()
+        if (current is UpdateState.Downloading) {
+            _state.value = UpdateState.Available(current.release)
+        }
+    }
 
     companion object {
         /** 6 hours. */

--- a/app/src/test/kotlin/com/realmsoffate/game/data/updater/ApkDownloaderTest.kt
+++ b/app/src/test/kotlin/com/realmsoffate/game/data/updater/ApkDownloaderTest.kt
@@ -1,0 +1,76 @@
+package com.realmsoffate.game.data.updater
+
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okio.Buffer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+import java.nio.file.Files
+
+class ApkDownloaderTest {
+    private lateinit var server: MockWebServer
+    private lateinit var tempDir: File
+    private lateinit var downloader: ApkDownloader
+
+    @Before fun setUp() {
+        server = MockWebServer().apply { start() }
+        tempDir = Files.createTempDirectory("apk-downloader-test").toFile()
+        downloader = ApkDownloader(OkHttpClient(), tempDir)
+    }
+
+    @After fun tearDown() {
+        server.shutdown()
+        tempDir.deleteRecursively()
+    }
+
+    @Test fun `downloads bytes to file matching expected size`() = runTest {
+        val payload = ByteArray(1024) { (it % 256).toByte() }
+        server.enqueue(MockResponse().setBody(Buffer().write(payload)))
+
+        val results = downloader.download(server.url("/x.apk").toString(), "out.apk", expectedSize = 1024L)
+            .toList()
+
+        val terminal = results.last()
+        assertTrue("expected Done as terminal, was $terminal", terminal is ApkDownloader.Progress.Done)
+        val file = (terminal as ApkDownloader.Progress.Done).file
+        assertEquals(1024L, file.length())
+        assertTrue(results.any { it is ApkDownloader.Progress.Streaming })
+    }
+
+    @Test fun `size mismatch fails with corrupt`() = runTest {
+        val payload = ByteArray(512)
+        server.enqueue(MockResponse().setBody(Buffer().write(payload)))
+
+        val results = downloader.download(
+            server.url("/x.apk").toString(),
+            "out.apk",
+            expectedSize = 9999L
+        ).toList()
+
+        val terminal = results.last()
+        assertTrue("terminal should be Failed, was $terminal", terminal is ApkDownloader.Progress.Failed)
+        assertTrue(
+            "Failed reason should mention corrupt or size",
+            (terminal as ApkDownloader.Progress.Failed).reason.contains("size", ignoreCase = true) ||
+                terminal.reason.contains("corrupt", ignoreCase = true)
+        )
+        assertEquals(0, tempDir.listFiles()?.size ?: 0)
+    }
+
+    @Test fun `http error fails`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(404))
+        val results = downloader.download(
+            server.url("/x.apk").toString(),
+            "out.apk",
+            expectedSize = 1L
+        ).toList()
+        assertTrue(results.last() is ApkDownloader.Progress.Failed)
+    }
+}

--- a/app/src/test/kotlin/com/realmsoffate/game/data/updater/UpdateRepositoryTest.kt
+++ b/app/src/test/kotlin/com/realmsoffate/game/data/updater/UpdateRepositoryTest.kt
@@ -42,13 +42,17 @@ class UpdateRepositoryTest {
     private var nowMs = 1_700_000_000_000L
     private val clock = { nowMs }
 
-    private fun newRepo(versionName: String = "0.1.0-alpha.1"): UpdateRepository =
+    private fun newRepo(
+        versionName: String = "0.1.0-alpha.1",
+        downloader: ApkDownloaderLike? = null
+    ): UpdateRepository =
         UpdateRepository(
             currentVersionName = versionName,
             client = client,
             prefs = prefs,
             clock = clock,
-            cacheTtlMs = UpdateRepository.DEFAULT_CACHE_TTL_MS
+            cacheTtlMs = UpdateRepository.DEFAULT_CACHE_TTL_MS,
+            downloader = downloader
         )
 
     @After fun tearDown() = runTest { prefs.clearForTest() }
@@ -202,4 +206,53 @@ class UpdateRepositoryTest {
         assertEquals(UpdateChannel.STABLE_ONLY, prefs.channel.first())
         assertEquals(1, client.calls)
     }
+
+    @Test fun `startDownload transitions to ReadyToInstall on success`() = runTest {
+        val rel = release("v0.2.0", assetName = "realms-v0.2.0-release.apk")
+        val tempFile = java.io.File.createTempFile("fake-apk", ".apk").apply { writeBytes(ByteArray(8)) }
+        val fakeDownloader = FakeDownloader().apply {
+            scriptedProgress = listOf(
+                ApkDownloader.Progress.Streaming(4, 8, 50),
+                ApkDownloader.Progress.Done(tempFile)
+            )
+        }
+        val repo = newRepo(downloader = fakeDownloader)
+        client.nextResult = GitHubReleasesClient.Result.Ok(listOf(rel))
+        repo.check(force = true).join()
+
+        repo.startDownload((repo.state.value as UpdateState.Available).release).join()
+        val terminal = repo.state.value
+        assertTrue("expected ReadyToInstall, was $terminal", terminal is UpdateState.ReadyToInstall)
+    }
+
+    @Test fun `download Failed reverts to Available`() = runTest {
+        val rel = release("v0.2.0", assetName = "realms-v0.2.0-release.apk")
+        val fakeDownloader = FakeDownloader().apply {
+            scriptedProgress = listOf(ApkDownloader.Progress.Failed("Network: no route"))
+        }
+        val repo = newRepo(downloader = fakeDownloader)
+        client.nextResult = GitHubReleasesClient.Result.Ok(listOf(rel))
+        repo.check(force = true).join()
+
+        repo.startDownload(rel).join()
+        val state = repo.state.value
+        assertTrue("expected Available after failure, was $state", state is UpdateState.Available)
+    }
+
+    @Test fun `download with no realms apk asset emits Error`() = runTest {
+        val rel = release("v0.2.0") // no asset
+        val repo = newRepo(downloader = FakeDownloader())
+        client.nextResult = GitHubReleasesClient.Result.Ok(listOf(rel))
+        repo.check(force = true).join()
+
+        repo.startDownload(rel).join()
+        val state = repo.state.value as UpdateState.Error
+        assertEquals(false, state.recoverable)
+    }
+}
+
+private class FakeDownloader : ApkDownloaderLike {
+    var scriptedProgress: List<ApkDownloader.Progress> = emptyList()
+    override fun download(downloadUrl: String, filename: String, expectedSize: Long) =
+        kotlinx.coroutines.flow.flow { scriptedProgress.forEach { emit(it) } }
 }


### PR DESCRIPTION
## Summary
- `ApkDownloader` streams APKs to a cache dir, emits `Flow<Progress>`, validates final size against the asset's declared size, cleans up on failure.
- `ApkDownloaderLike` test seam keeps `UpdateRepositoryTest` independent of OkHttp/temp-dir setup.
- `UpdateRepository.startDownload` / `cancelDownload` reduce progress events into `UpdateState` transitions. `Failed` reverts to `Available` so the user can retry.
- 6 new tests (3 `ApkDownloader` MockWebServer + 3 download integration in `UpdateRepositoryTest`).
- Install hand-off lands in M5b.

Spec: [`docs/superpowers/specs/2026-05-01-phase7-auto-update-system-design.md`](docs/superpowers/specs/2026-05-01-phase7-auto-update-system-design.md)

## Test plan
- [x] `gradle :app:testDebugUnitTest --tests "com.realmsoffate.game.data.updater.*"` passes locally (57/57)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)