### PR TITLE
feat(phase7-updater): M5b — install hand-off + signature check (#28)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
     <application
         android:name=".RealmsApp"
@@ -15,6 +16,16 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.RealmsOfFate">
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.updates"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/updater_file_paths" />
+        </provider>
 
         <provider
             android:name="androidx.startup.InitializationProvider"

--- a/app/src/main/kotlin/com/realmsoffate/game/data/updater/InstallLauncher.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/data/updater/InstallLauncher.kt
@@ -1,0 +1,84 @@
+package com.realmsoffate.game.data.updater
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.content.pm.Signature
+import android.os.Build
+import androidx.core.content.FileProvider
+import java.io.File
+import java.security.MessageDigest
+
+/**
+ * Bridges UpdateRepository's ReadyToInstall state to Android's package
+ * installer. Owns the FileProvider URI construction and signature mismatch
+ * detection (used in debug builds to warn the user that installing the
+ * release APK over a debug build will require an uninstall + data wipe).
+ */
+object InstallLauncher {
+
+    /** Build the install intent for [apk] using the updater's FileProvider. */
+    fun buildIntent(context: Context, apk: File): Intent {
+        val authority = "${context.packageName}.updates"
+        val uri = FileProvider.getUriForFile(context, authority, apk)
+        return Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType(uri, "application/vnd.android.package-archive")
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+    }
+
+    /**
+     * True if the APK at [apk] is signed by a different cert than the running
+     * package. Returns false when we can't determine (treat as "no warning").
+     *
+     * Used in debug builds: a debug-signed install replacing a release-signed
+     * APK (or vice versa) will trigger Android's signature-mismatch error and
+     * require an uninstall, which deletes save data.
+     */
+    fun signatureMismatchAgainstInstalled(context: Context, apk: File): Boolean {
+        return try {
+            val installedSigs = installedSignatures(context, context.packageName) ?: return false
+            val pkgSigs = apkSignatures(context, apk) ?: return false
+            installedSigs != pkgSigs
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    private fun installedSignatures(context: Context, packageName: String): Set<String>? {
+        val pm = context.packageManager
+        @Suppress("DEPRECATION")
+        val info = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            pm.getPackageInfo(packageName, PackageManager.GET_SIGNING_CERTIFICATES)
+        } else {
+            pm.getPackageInfo(packageName, PackageManager.GET_SIGNATURES)
+        }
+        val sigs = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            info.signingInfo?.apkContentsSigners ?: info.signingInfo?.signingCertificateHistory
+        } else {
+            @Suppress("DEPRECATION") info.signatures
+        } ?: return null
+        return sigs.map { sha256(it) }.toSet()
+    }
+
+    private fun apkSignatures(context: Context, apk: File): Set<String>? {
+        val pm = context.packageManager
+        @Suppress("DEPRECATION")
+        val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P)
+            PackageManager.GET_SIGNING_CERTIFICATES
+        else PackageManager.GET_SIGNATURES
+        val info = pm.getPackageArchiveInfo(apk.absolutePath, flags) ?: return null
+        val sigs = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            info.signingInfo?.apkContentsSigners ?: info.signingInfo?.signingCertificateHistory
+        } else {
+            @Suppress("DEPRECATION") info.signatures
+        } ?: return null
+        return sigs.map { sha256(it) }.toSet()
+    }
+
+    private fun sha256(sig: Signature): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(sig.toByteArray())
+        return digest.joinToString("") { "%02x".format(it) }
+    }
+}

--- a/app/src/main/res/xml/updater_file_paths.xml
+++ b/app/src/main/res/xml/updater_file_paths.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Exposes <cacheDir>/updates/ to the system installer for ACTION_INSTALL_PACKAGE. -->
+    <cache-path name="updates" path="updates/" />
+</paths>

--- a/app/src/test/kotlin/com/realmsoffate/game/data/updater/InstallLauncherTest.kt
+++ b/app/src/test/kotlin/com/realmsoffate/game/data/updater/InstallLauncherTest.kt
@@ -1,0 +1,38 @@
+package com.realmsoffate.game.data.updater
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+class InstallLauncherTest {
+    private val ctx: Context = ApplicationProvider.getApplicationContext()
+    private val tempApk = File(ctx.cacheDir, "updates").let { dir ->
+        dir.mkdirs()
+        File(dir, "fake.apk").apply { writeBytes(ByteArray(8)) }
+    }
+
+    @Test fun `buildIntent returns installer intent with file uri`() {
+        val intent = InstallLauncher.buildIntent(ctx, tempApk)
+        assertNotNull(intent)
+        assertNotNull(intent.data)
+        val expectedAuthority = "${ctx.packageName}.updates"
+        assertTrue(
+            "expected authority $expectedAuthority, got ${intent.data!!.authority}",
+            intent.data!!.authority == expectedAuthority
+        )
+        assertTrue(intent.action == android.content.Intent.ACTION_VIEW)
+    }
+
+    @Test fun `signatureMismatch does not throw on missing data`() {
+        // Robolectric's package archive parsing won't find signatures in our 8-byte
+        // fake APK; the helper should return false rather than crash.
+        val mismatch = InstallLauncher.signatureMismatchAgainstInstalled(ctx, tempApk)
+        assertTrue("expected non-throw; mismatch=$mismatch", mismatch == true || mismatch == false)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `REQUEST_INSTALL_PACKAGES` permission and a FileProvider (`\${applicationId}.updates`) backed by `<cacheDir>/updates/`.
- `InstallLauncher.buildIntent` constructs the `ACTION_VIEW` install intent with the FileProvider URI + `FLAG_GRANT_READ_URI_PERMISSION`.
- `InstallLauncher.signatureMismatchAgainstInstalled` SHA-256s installed-package signatures against the downloaded APK's, so debug builds can warn the user before Android's mismatch error forces an uninstall (data wipe).
- 2 Robolectric tests (intent shape + non-throwing sig check on degenerate APK).

Spec: [`docs/superpowers/specs/2026-05-01-phase7-auto-update-system-design.md`](docs/superpowers/specs/2026-05-01-phase7-auto-update-system-design.md)

## Test plan
- [x] `gradle :app:testDebugUnitTest --tests "com.realmsoffate.game.data.updater.*"` passes locally (59/59)
- [x] `gradle assembleDebug` builds clean
- [x] App launches on emulator with new manifest (debug-bridge `/describe` confirms ApiSetup renders)
- [ ] CI green
- [ ] Manual install-flow check is M6 territory (no UI to trigger startDownload yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)