### PR TITLE
feat(phase7-updater): M6 — UI + cold-start wiring (#28)

### DIFF
--- a/app/src/debug/kotlin/com/realmsoffate/game/debug/CommandEndpoints.kt
+++ b/app/src/debug/kotlin/com/realmsoffate/game/debug/CommandEndpoints.kt
@@ -98,7 +98,8 @@ object CommandEndpoints {
                 "charactercreation" -> Screen.CharacterCreation
                 "game" -> Screen.Game
                 "death" -> Screen.Death
-                else -> return@route HttpResponse.error(400, "Unknown screen '$screenName'. Valid values: apiSetup, title, characterCreation, game, death")
+                "settings" -> Screen.Settings
+                else -> return@route HttpResponse.error(400, "Unknown screen '$screenName'. Valid values: apiSetup, title, characterCreation, game, death, settings")
             }
 
             val vm = DebugBridge.requireVm()

--- a/app/src/debug/kotlin/com/realmsoffate/game/debug/DebugServer.kt
+++ b/app/src/debug/kotlin/com/realmsoffate/game/debug/DebugServer.kt
@@ -64,6 +64,7 @@ object DebugServer {
         RepoEndpoints.register()
         AiDebugEndpoints.register()
         ContentEndpoints.register()
+        UpdaterEndpoints.register()
 
         scope.launch {
             try {

--- a/app/src/debug/kotlin/com/realmsoffate/game/debug/UpdaterEndpoints.kt
+++ b/app/src/debug/kotlin/com/realmsoffate/game/debug/UpdaterEndpoints.kt
@@ -1,0 +1,42 @@
+package com.realmsoffate.game.debug
+
+import com.realmsoffate.game.data.updater.UpdateRepositoryHolder
+import com.realmsoffate.game.data.updater.UpdateState
+
+/**
+ * Phase 7 — debug-only endpoints for the auto-update system.
+ *
+ *  POST /updater/check    Forces UpdateRepository.check(force = true), bypassing
+ *                         the 6h cache. Returns immediately with the prior state
+ *                         tag; the actual check is asynchronous and reflected in
+ *                         /describe once it lands.
+ *
+ *  GET  /updater/state    Snapshot of the current UpdateState as a small JSON
+ *                         object (kind + tag where applicable).
+ */
+object UpdaterEndpoints {
+    fun register() {
+        DebugServer.route("POST", "/updater/check") { _ ->
+            UpdateRepositoryHolder.instance.check(force = true)
+            HttpResponse.json("""{"ok":true,"prior":${currentStateJson()}}""")
+        }
+
+        DebugServer.route("GET", "/updater/state") { _ ->
+            HttpResponse.json(currentStateJson())
+        }
+    }
+
+    private fun currentStateJson(): String {
+        return when (val s = UpdateRepositoryHolder.instance.state.value) {
+            UpdateState.Idle -> """{"kind":"Idle"}"""
+            UpdateState.Checking -> """{"kind":"Checking"}"""
+            UpdateState.UpToDate -> """{"kind":"UpToDate"}"""
+            is UpdateState.Available -> """{"kind":"Available","tag":"${s.release.tag.jsonEscape()}"}"""
+            is UpdateState.Downloading -> """{"kind":"Downloading","tag":"${s.release.tag.jsonEscape()}","progress":${s.progress}}"""
+            is UpdateState.ReadyToInstall -> """{"kind":"ReadyToInstall","tag":"${s.release.tag.jsonEscape()}"}"""
+            is UpdateState.Error -> """{"kind":"Error","reason":"${s.reason.jsonEscape()}","recoverable":${s.recoverable}}"""
+        }
+    }
+}
+
+private fun String.jsonEscape(): String = replace("\\", "\\\\").replace("\"", "\\\"")

--- a/app/src/main/kotlin/com/realmsoffate/game/MainActivity.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/MainActivity.kt
@@ -10,10 +10,14 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import com.realmsoffate.game.data.updater.InstallLauncher
+import com.realmsoffate.game.data.updater.UpdateRepositoryHolder
+import com.realmsoffate.game.data.updater.UpdateState
 import com.realmsoffate.game.game.GameViewModel
 import com.realmsoffate.game.game.Screen
 import com.realmsoffate.game.ui.game.GameScreen
@@ -40,7 +44,37 @@ class MainActivity : ComponentActivity() {
                     color = MaterialTheme.colorScheme.background
                 ) {
                     RealmsRoot(viewModel)
+                    ObserveUpdateInstall(this@MainActivity)
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ObserveUpdateInstall(activity: ComponentActivity) {
+    val state by UpdateRepositoryHolder.instance.state.collectAsState()
+    LaunchedEffect(state) {
+        val s = state
+        if (s is UpdateState.ReadyToInstall) {
+            val mismatch = BuildConfig.DEBUG &&
+                InstallLauncher.signatureMismatchAgainstInstalled(activity, s.file)
+            val launch = {
+                runCatching { activity.startActivity(InstallLauncher.buildIntent(activity, s.file)) }
+            }
+            if (mismatch) {
+                android.app.AlertDialog.Builder(activity)
+                    .setTitle("Replace debug build?")
+                    .setMessage(
+                        "Installing the release build will conflict with this debug build's " +
+                        "signing certificate. Android will require you to uninstall first, which " +
+                        "deletes save data. Continue?"
+                    )
+                    .setPositiveButton("Continue") { _, _ -> launch() }
+                    .setNegativeButton("Cancel", null)
+                    .show()
+            } else {
+                launch()
             }
         }
     }

--- a/app/src/main/kotlin/com/realmsoffate/game/MainActivity.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/MainActivity.kt
@@ -19,6 +19,7 @@ import com.realmsoffate.game.game.Screen
 import com.realmsoffate.game.ui.game.GameScreen
 import com.realmsoffate.game.ui.setup.ApiSetupScreen
 import com.realmsoffate.game.ui.setup.CharacterCreationScreen
+import com.realmsoffate.game.ui.settings.SettingsScreen
 import com.realmsoffate.game.ui.setup.DeathScreen
 import com.realmsoffate.game.ui.setup.TitleScreen
 import com.realmsoffate.game.ui.theme.RealmsTheme
@@ -54,5 +55,6 @@ fun RealmsRoot(vm: GameViewModel) {
         Screen.CharacterCreation -> CharacterCreationScreen(vm)
         Screen.Game -> GameScreen(vm)
         Screen.Death -> DeathScreen(vm)
+        Screen.Settings -> SettingsScreen(vm)
     }
 }

--- a/app/src/main/kotlin/com/realmsoffate/game/RealmsApp.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/RealmsApp.kt
@@ -7,6 +7,7 @@ import com.realmsoffate.game.BuildConfig
 import com.realmsoffate.game.data.SaveStore
 import com.realmsoffate.game.data.content.ContentRepository
 import com.realmsoffate.game.data.db.RealmsDbHolder
+import com.realmsoffate.game.data.updater.UpdateRepositoryHolder
 import java.util.concurrent.Executors
 
 class RealmsApp : Application() {
@@ -17,6 +18,8 @@ class RealmsApp : Application() {
         EmojiCompat.init(BundledEmojiCompatConfig(this, Executors.newSingleThreadExecutor()))
         SaveStore.init(this)
         RealmsDbHolder.init(this)
+        UpdateRepositoryHolder.init(this, BuildConfig.VERSION_NAME)
+        UpdateRepositoryHolder.instance.check(force = false)
         if (BuildConfig.DEBUG) {
             try {
                 val bridge = Class.forName("com.realmsoffate.game.debug.DebugBridge")

--- a/app/src/main/kotlin/com/realmsoffate/game/data/updater/UpdateRepository.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/data/updater/UpdateRepository.kt
@@ -147,8 +147,42 @@ class UpdateRepository(
         }
     }
 
+    /** UI-friendly: pass-throughs for the prefs flows. */
+    fun observableChannel(): kotlinx.coroutines.flow.Flow<UpdateChannel> = prefs.channel
+    fun observableLastCheckedAt(): kotlinx.coroutines.flow.Flow<Long?> = prefs.lastCheckedAt
+
     companion object {
         /** 6 hours. */
         const val DEFAULT_CACHE_TTL_MS: Long = 6L * 60L * 60L * 1000L
     }
+}
+
+/**
+ * Process-level holder so MainActivity / Compose can grab the repository
+ * without DI. Mirrors RealmsDbHolder / ContentRepository conventions.
+ */
+object UpdateRepositoryHolder {
+    @Volatile private var repo: UpdateRepository? = null
+
+    fun init(
+        context: android.content.Context,
+        currentVersionName: String,
+    ) {
+        if (repo != null) return
+        val httpClient = GitHubReleasesClient.defaultHttpClient()
+        val client = GitHubReleasesSource(
+            GitHubReleasesClient(httpClient = httpClient, userAgent = "Realms/$currentVersionName")
+        )
+        val prefs = UpdatePrefs(context.applicationContext)
+        val downloader = ApkDownloader(httpClient, java.io.File(context.cacheDir, "updates"))
+        repo = UpdateRepository(
+            currentVersionName = currentVersionName,
+            client = client,
+            prefs = prefs,
+            downloader = downloader
+        )
+    }
+
+    val instance: UpdateRepository
+        get() = repo ?: error("UpdateRepositoryHolder not initialized")
 }

--- a/app/src/main/kotlin/com/realmsoffate/game/game/GameViewModel.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/game/GameViewModel.kt
@@ -62,7 +62,7 @@ import com.realmsoffate.game.game.reducers.SceneBoundaryDetector
 import com.realmsoffate.game.data.db.RealmsDbHolder
 import kotlinx.coroutines.flow.update
 
-enum class Screen { ApiSetup, Title, CharacterCreation, Game, Death }
+enum class Screen { ApiSetup, Title, CharacterCreation, Game, Death, Settings }
 
 data class GameUiState(
     val character: Character? = null,
@@ -667,6 +667,9 @@ class GameViewModel(
     fun backToApiSetup() {
         _screen.value = Screen.ApiSetup
     }
+
+    fun openSettings() { _screen.value = Screen.Settings }
+    fun closeSettings() { _screen.value = Screen.Title }
 
     fun setApiKey(k: String) {
         _apiKey.value = k

--- a/app/src/main/kotlin/com/realmsoffate/game/ui/components/UpdateBanner.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/ui/components/UpdateBanner.kt
@@ -1,0 +1,92 @@
+package com.realmsoffate.game.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.realmsoffate.game.data.updater.ReleaseInfo
+import com.realmsoffate.game.data.updater.UpdateRepositoryHolder
+import com.realmsoffate.game.data.updater.UpdateState
+
+/**
+ * Title-screen banner. Shows for `Available` (when not dismissed),
+ * `Downloading`, and `ReadyToInstall`. Hidden in all other states.
+ */
+@Composable
+fun UpdateBanner(modifier: Modifier = Modifier) {
+    val repo = remember { UpdateRepositoryHolder.instance }
+    val state by repo.state.collectAsState()
+    val release: ReleaseInfo? = when (val s = state) {
+        is UpdateState.Available -> s.release
+        is UpdateState.Downloading -> s.release
+        is UpdateState.ReadyToInstall -> s.release
+        else -> null
+    }
+    if (release == null) return
+
+    var dismissedThisSession by remember { mutableStateOf(false) }
+    var bannerVisible by remember { mutableStateOf(true) }
+    LaunchedEffect(release.tag) {
+        bannerVisible = repo.bannerVisibleFor(release)
+    }
+    if (!bannerVisible || dismissedThisSession) return
+
+    Surface(
+        modifier = modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+        color = MaterialTheme.colorScheme.primaryContainer,
+        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        shape = MaterialTheme.shapes.medium,
+        tonalElevation = 2.dp
+    ) {
+        Column(Modifier.padding(16.dp)) {
+            Text("Update available: ${release.tag}", style = MaterialTheme.typography.titleSmall)
+            Text(
+                release.body.lineSequence().firstOrNull()?.trim()?.takeIf { it.isNotEmpty() } ?: release.name,
+                style = MaterialTheme.typography.bodySmall
+            )
+            Spacer(Modifier.height(8.dp))
+            when (val s = state) {
+                is UpdateState.Available -> Row(
+                    Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Button(onClick = { repo.startDownload(release) }) { Text("Update") }
+                    TextButton(onClick = { dismissedThisSession = true }) { Text("Later") }
+                    TextButton(onClick = {
+                        repo.dismissBannerForVersion(release.tag)
+                        dismissedThisSession = true
+                    }) { Text("Skip this version") }
+                }
+                is UpdateState.Downloading -> Column {
+                    Text("Downloading… ${s.progress}%", style = MaterialTheme.typography.bodySmall)
+                    LinearProgressIndicator(
+                        progress = { s.progress / 100f },
+                        modifier = Modifier.fillMaxWidth().padding(top = 4.dp)
+                    )
+                    TextButton(onClick = { repo.cancelDownload() }) { Text("Cancel") }
+                }
+                is UpdateState.ReadyToInstall ->
+                    Button(onClick = { repo.startDownload(release) }) { Text("Install") }
+                else -> Unit
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/realmsoffate/game/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/ui/settings/SettingsScreen.kt
@@ -1,0 +1,149 @@
+package com.realmsoffate.game.ui.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.realmsoffate.game.BuildConfig
+import com.realmsoffate.game.data.updater.ReleaseInfo
+import com.realmsoffate.game.data.updater.UpdateChannel
+import com.realmsoffate.game.data.updater.UpdateRepositoryHolder
+import com.realmsoffate.game.data.updater.UpdateState
+import com.realmsoffate.game.game.GameViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsScreen(vm: GameViewModel) {
+    val repo = remember { UpdateRepositoryHolder.instance }
+    val state by repo.state.collectAsState()
+    val channel by repo.observableChannel().collectAsState(initial = UpdateChannel.DEFAULT)
+    val lastChecked by repo.observableLastCheckedAt().collectAsState(initial = null)
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Settings") },
+                navigationIcon = {
+                    IconButton(onClick = { vm.closeSettings() }) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 16.dp, vertical = 12.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            SettingsSection("App") {
+                LabeledRow("Version", BuildConfig.VERSION_NAME)
+            }
+
+            SettingsSection("Updates") {
+                LabeledRow("Last checked", relativeTime(lastChecked))
+                ChannelToggleRow(
+                    channel = channel,
+                    onChange = { repo.setChannel(it) }
+                )
+                CheckNowRow(
+                    enabled = state !is UpdateState.Checking && state !is UpdateState.Downloading,
+                    onCheck = { repo.check(force = true) }
+                )
+                UpdateStatusRow(state = state, onUpdate = { release -> repo.startDownload(release) })
+            }
+        }
+    }
+}
+
+@Composable
+private fun SettingsSection(title: String, content: @Composable () -> Unit) {
+    Column(Modifier.fillMaxWidth()) {
+        Text(title, style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.primary)
+        Spacer(Modifier.height(4.dp))
+        content()
+    }
+}
+
+@Composable
+private fun LabeledRow(label: String, value: String) {
+    Row(
+        Modifier.fillMaxWidth().padding(vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(label, modifier = Modifier.weight(1f), style = MaterialTheme.typography.bodyMedium)
+        Text(value, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+}
+
+@Composable
+private fun ChannelToggleRow(channel: UpdateChannel, onChange: (UpdateChannel) -> Unit) {
+    Row(
+        Modifier.fillMaxWidth().padding(vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text("Include prereleases", modifier = Modifier.weight(1f), style = MaterialTheme.typography.bodyMedium)
+        Switch(
+            checked = channel == UpdateChannel.INCLUDE_PRERELEASES,
+            onCheckedChange = { on ->
+                onChange(if (on) UpdateChannel.INCLUDE_PRERELEASES else UpdateChannel.STABLE_ONLY)
+            }
+        )
+    }
+}
+
+@Composable
+private fun CheckNowRow(enabled: Boolean, onCheck: () -> Unit) {
+    TextButton(onClick = onCheck, enabled = enabled) { Text("Check for updates now") }
+}
+
+@Composable
+private fun UpdateStatusRow(state: UpdateState, onUpdate: (ReleaseInfo) -> Unit) {
+    when (state) {
+        is UpdateState.Available ->
+            TextButton(onClick = { onUpdate(state.release) }) { Text("Update to ${state.release.tag}") }
+        is UpdateState.Downloading ->
+            Text("Downloading… ${state.progress}%", style = MaterialTheme.typography.bodyMedium)
+        is UpdateState.ReadyToInstall ->
+            TextButton(onClick = { onUpdate(state.release) }) { Text("Install ${state.release.tag}") }
+        is UpdateState.Error ->
+            Text(state.reason, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+        UpdateState.Idle, UpdateState.Checking, UpdateState.UpToDate -> Unit
+    }
+}
+
+private fun relativeTime(epochMs: Long?): String {
+    if (epochMs == null) return "Never"
+    val deltaMs = System.currentTimeMillis() - epochMs
+    if (deltaMs < 60_000L) return "Just now"
+    if (deltaMs < 3_600_000L) return "${deltaMs / 60_000L}m ago"
+    if (deltaMs < 86_400_000L) return "${deltaMs / 3_600_000L}h ago"
+    return "${deltaMs / 86_400_000L}d ago"
+}

--- a/app/src/main/kotlin/com/realmsoffate/game/ui/setup/TitleScreen.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/ui/setup/TitleScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.unit.sp
 import com.realmsoffate.game.data.GraveyardEntry
 import com.realmsoffate.game.data.SaveSlotMeta
 import com.realmsoffate.game.game.GameViewModel
+import com.realmsoffate.game.ui.components.UpdateBanner
 import com.realmsoffate.game.ui.theme.RealmsSpacing
 
 /**
@@ -103,7 +104,9 @@ fun TitleScreen(vm: GameViewModel) {
                 style = MaterialTheme.typography.labelMedium.copy(letterSpacing = 3.sp),
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
-            Spacer(Modifier.height(40.dp))
+            Spacer(Modifier.height(16.dp))
+            UpdateBanner()
+            Spacer(Modifier.height(24.dp))
 
             val latest = slots.firstOrNull()
 
@@ -169,6 +172,13 @@ fun TitleScreen(vm: GameViewModel) {
                     label = "API Setup",
                     enabled = true,
                     onClick = { vm.backToApiSetup() },
+                    modifier = Modifier.weight(1f)
+                )
+                SecondaryTile(
+                    icon = Icons.Default.Settings,
+                    label = "Settings",
+                    enabled = true,
+                    onClick = { vm.openSettings() },
                     modifier = Modifier.weight(1f)
                 )
             }


### PR DESCRIPTION
## Summary
Wires the auto-update system end-to-end. Closes Phase 7 (#28).

- **Singleton + cold start.** `UpdateRepositoryHolder.init` runs in `RealmsApp.onCreate`; a non-forced `check()` fires immediately so the title screen reflects state on first paint.
- **`Screen.Settings` + `SettingsScreen`.** New screen with App > Version, Updates > Last checked, Include-prereleases switch, Check-for-updates-now button, and a status row that shows Available / Downloading / ReadyToInstall / Error.
- **`UpdateBanner`** on TitleScreen between the title block and the tile grid. Shows for Available (when not dismissed), Downloading (with progress + cancel), and ReadyToInstall. Per-version dismiss persists; "Later" is session-only.
- **Settings tile** on TitleScreen alongside Graveyard / API Setup.
- **Install dispatch.** `MainActivity` observes `ReadyToInstall` and fires the system install intent. Debug builds first run `signatureMismatchAgainstInstalled` and show an AlertDialog warning before launching, since the release-signed APK conflicts with the debug-signed install.
- **Debug bridge.** New `POST /updater/check` (force) and `GET /updater/state` endpoints, plus `settings` added to `POST /navigate`.

Spec: [`docs/superpowers/specs/2026-05-01-phase7-auto-update-system-design.md`](docs/superpowers/specs/2026-05-01-phase7-auto-update-system-design.md)

## Test plan
- [x] `gradle :app:testDebugUnitTest --tests "com.realmsoffate.game.data.updater.*"` passes locally (59/59)
- [x] `gradle assembleDebug` builds clean
- [x] App launches; cold-start check hits GitHub and reaches `UpToDate` (BuildConfig.VERSION_NAME matches the only published release)
- [x] `POST /updater/check` returns `{"ok":true,"prior":{...}}`; `GET /updater/state` returns the live state
- [x] `POST /navigate {"screen":"title"}` shows the new Settings tile in the bottom row
- [x] `POST /navigate {"screen":"settings"}` renders SettingsScreen with all rows (Version, Last checked, Include prereleases, Check now)
- [ ] Manual: signature-mismatch dialog when forcing a release-APK install over a debug build (deferred to actual release-cycle verification)
- [ ] Lint failures are pre-existing (`enforceStatusBarContrast` API level + others in `values-night/themes.xml`) and unrelated to updater code
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)