### PR TITLE
fix(narration): render player_dialog as chat bubble (#54)

### DIFF
--- a/app/src/main/kotlin/com/realmsoffate/game/ui/game/NarrationBlock.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/ui/game/NarrationBlock.kt
@@ -103,7 +103,9 @@ internal fun NarrationBlock(
                     is NarrationSegmentData.PlayerAction -> {
                         PlayerActionLine(text = seg.text)
                     }
-                    is NarrationSegmentData.PlayerDialog -> {}
+                    is NarrationSegmentData.PlayerDialog -> Dim(dimAlpha) {
+                        PlayerBubble(text = seg.text, characterName = characterName)
+                    }
                 }
             }
             // Stat change strip (with optional inline check chip) at the end — dimmed with the turn
@@ -149,7 +151,9 @@ internal fun NarrationBlock(
                             )
                         }
                     }
-                    is NarrationSegment.PlayerDialogue -> {}
+                    is NarrationSegment.PlayerDialogue -> Dim(dimAlpha) {
+                        PlayerBubble(text = seg.quote, characterName = characterName)
+                    }
                     is NarrationSegment.Action -> Dim(dimAlpha) {
                         NarratorAsideLine(text = seg.text)
                     }


### PR DESCRIPTION
## Summary
- `PlayerDialog` cases in both the structured and legacy render paths in `NarrationBlock.kt` were no-ops, so PC speech disappeared into the surrounding narrator prose.
- Wire them through the existing `PlayerBubble` composable, using `characterName` already passed into `NarrationBlock`.

Fixes #54.

## Test plan
- [x] `gradle assembleDebug` clean
- [x] Parser unit tests still pass (`gradle :app:testDebugUnitTest --tests "*EnvelopeParser*" --tests "*TagParser*"`)
- [x] Debug-bridge P0 + P1 (state 200, screenshot OK)
- [x] Contextual: `/inject/messages` with mixed narrator + NPC + PC dialogue → PC line "I am here to trade…" renders as a right-aligned bubble distinct from narrator rail and NPC bubble (legacy regex path).
- [ ] Structured path (real AI envelope) inherits the same `PlayerBubble` call, exercised in normal play.

🤖 Generated with [Claude Code](https://claude.com/claude-code)