### PR TITLE
fix(journal): swipe-right on NPC bubble lands on NPCs sub-tab (#49)

### DIFF
--- a/app/src/main/kotlin/com/realmsoffate/game/ui/game/JournalPager.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/ui/game/JournalPager.kt
@@ -40,6 +40,17 @@ internal fun JournalPager(
         }
     }
 
+    // When a swipe-right on an NPC bubble brings us here with a focused NPC,
+    // jump to the NPCs sub-tab — that's the "NPC log" the user expects.
+    LaunchedEffect(focusNpc) {
+        if (focusNpc != null) {
+            val target = tabs.indexOf(JournalTab.Npcs)
+            if (target >= 0 && pagerState.currentPage != target) {
+                pagerState.animateScrollToPage(target)
+            }
+        }
+    }
+
     Column(Modifier.fillMaxSize()) {
         PanelTabRow(
             tabs = tabs.map { t ->

--- a/app/src/main/kotlin/com/realmsoffate/game/ui/game/NarrationBlock.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/ui/game/NarrationBlock.kt
@@ -73,7 +73,7 @@ internal fun NarrationBlock(
                             onSwipeLeft = if (isLatestTurn) { { onAttackNpc(displayName) } } else { {} },
                             onSwipeRight = { onOpenJournal(displayName) },
                             leftLabel = if (isLatestTurn) "Attack" else null,
-                            rightLabel = "Journal",
+                            rightLabel = "NPC Log",
                             leftIcon = if (isLatestTurn) Icons.Filled.GpsFixed else null,
                             rightIcon = Icons.Filled.Book
                         ) {
@@ -137,7 +137,7 @@ internal fun NarrationBlock(
                             onSwipeLeft = if (isLatestTurn) { { onAttackNpc(seg.name) } } else { {} },
                             onSwipeRight = { onOpenJournal(seg.name) },
                             leftLabel = if (isLatestTurn) "Attack" else null,
-                            rightLabel = "Journal",
+                            rightLabel = "NPC Log",
                             leftIcon = if (isLatestTurn) Icons.Filled.Bolt else null,
                             rightIcon = Icons.Filled.Book
                         ) {


### PR DESCRIPTION
## Summary
- Swiping right on an NPC bubble already set ``focusNpc`` and switched to the Journal tab, but ``JournalPager`` left the user on whatever sub-tab the pager last had (Quests / Lore), so the focused NPC could be one or two pages over.
- Add a ``LaunchedEffect(focusNpc)`` in ``JournalPager`` to scroll to the NPCs sub-tab when ``focusNpc`` becomes non-null.
- Rename the swipe-right affordance label "Journal" → "NPC Log" in both the structured and legacy render paths so the label matches the destination.

Fixes #49.

## Test plan
- [x] ``gradle assembleDebug`` clean
- [x] Debug-bridge P0 + P1 (state 200, screenshot OK)
- [x] Contextual: inject an NPC dialogue bubble, ``adb input swipe`` left→right on it. Result: lands on Journal tab with NPCs sub-tab selected (not Quests default).
- [ ] In a real save with multiple NPCs, focused NPC entry expands as expected (covered by existing ``focusNpc`` plumbing in ``JournalContent``).

🤖 Generated with [Claude Code](https://claude.com/claude-code)