### PR TITLE
chore(deepseek): bump default model to deepseek-v4-flash (#53)

### DIFF
--- a/app/src/main/kotlin/com/realmsoffate/game/data/AiRepository.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/data/AiRepository.kt
@@ -156,7 +156,7 @@ class AiRepository(
             }
         }
         val body = buildJsonObject {
-            put("model", "deepseek-chat")
+            put("model", "deepseek-v4-flash")
             put("max_tokens", 1800)
             put("temperature", 1.0)
             put("top_p", 0.95)
@@ -214,7 +214,7 @@ If the action is combat/attacking, respond "Attack". If purely dialogue with no 
                 })
             }
             val body = buildJsonObject {
-                put("model", "deepseek-chat")
+                put("model", "deepseek-v4-flash")
                 put("max_tokens", 10)
                 put("temperature", 0.0)
                 put("messages", messages)
@@ -295,7 +295,7 @@ If the action is combat/attacking, respond "Attack". If purely dialogue with no 
                 })
             }
             val body = buildJsonObject {
-                put("model", "deepseek-chat")
+                put("model", "deepseek-v4-flash")
                 put("max_tokens", 400)
                 put("temperature", 0.2)
                 put("messages", messages)
@@ -347,7 +347,7 @@ If the action is combat/attacking, respond "Attack". If purely dialogue with no 
                 })
             }
             val body = buildJsonObject {
-                put("model", "deepseek-chat")
+                put("model", "deepseek-v4-flash")
                 put("max_tokens", 500)
                 put("temperature", 0.2)
                 put("messages", messages)


### PR DESCRIPTION
## Summary
- DeepSeek's ``deepseek-chat`` alias is [deprecated on 2026-07-24](https://api-docs.deepseek.com/quick_start/pricing) and currently maps to ``deepseek-v4-flash``'s non-thinking mode.
- Switch the four ``AiRepository`` call sites to the explicit ``deepseek-v4-flash`` ID so we keep working past the deprecation date and pick up the 1M-token context window today.
- ``ApiSetupScreen`` blurb (``\$0.28/M tokens``) is still accurate for v4-flash output pricing, so the copy is unchanged.

Fixes #53.

## Test plan
- [x] ``gradle assembleDebug`` clean
- [x] ``gradle :app:testDebugUnitTest --tests "*AiRepository*"`` passes
- [x] Debug-bridge P0 + P1 (state 200, screenshot OK; ApiSetup screen reads correctly)
- [ ] Live API round trip (requires a DeepSeek key — leaving for whoever merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)