### PR TITLE
fix(ui): title tile wrap + char-creation glyph buttons (#50, #51, #52)

### DIFF
--- a/app/src/main/kotlin/com/realmsoffate/game/ui/setup/CharacterCreationScreen.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/ui/setup/CharacterCreationScreen.kt
@@ -12,7 +12,9 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material.icons.filled.Casino
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -287,20 +289,25 @@ private fun IdentityStep(
         modifier = Modifier.fillMaxWidth()
     )
     Spacer(Modifier.height(RealmsSpacing.xs))
-    OutlinedButton(
-        onClick = onRandom,
-        modifier = Modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.medium
+    Row(
+        Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(RealmsSpacing.s)
     ) {
-        Icon(Icons.Default.AutoAwesome, null, Modifier.size(18.dp))
-        Spacer(Modifier.width(6.dp))
-        Text("Randomize Everything")
+        Text(
+            "Roll a complete character: name, look, race, class, stats, all randomized. Lands on the final review.",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f)
+        )
+        FilledIconButton(onClick = onRandom) {
+            Icon(
+                Icons.Default.Casino,
+                contentDescription = "Randomize everything",
+                modifier = Modifier.size(20.dp)
+            )
+        }
     }
-    Text(
-        "Roll a complete character: name, look, race, class, stats, all randomized. Lands on the final review.",
-        style = MaterialTheme.typography.labelSmall,
-        color = MaterialTheme.colorScheme.onSurfaceVariant
-    )
     SectionHeader("GENDER")
     ChipRow(
         options = listOf("Male", "Female", "Non-binary", "Unspecified"),
@@ -476,11 +483,13 @@ private fun StatsStep(
                 color = if (remaining < 0) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
-        AssistChip(
-            onClick = onRecommend,
-            label = { Text("Recommended") },
-            leadingIcon = { Icon(Icons.Default.AutoAwesome, null, Modifier.size(18.dp)) }
-        )
+        FilledIconButton(onClick = onRecommend) {
+            Icon(
+                Icons.Default.Star,
+                contentDescription = "Recommended stats",
+                modifier = Modifier.size(20.dp)
+            )
+        }
     }
     labels.forEachIndexed { i, label ->
         val bonus = when (i) {

--- a/app/src/main/kotlin/com/realmsoffate/game/ui/setup/TitleScreen.kt
+++ b/app/src/main/kotlin/com/realmsoffate/game/ui/setup/TitleScreen.kt
@@ -169,16 +169,22 @@ fun TitleScreen(vm: GameViewModel) {
                 )
                 SecondaryTile(
                     icon = Icons.Default.Settings,
-                    label = "API Setup",
-                    enabled = true,
-                    onClick = { vm.backToApiSetup() },
-                    modifier = Modifier.weight(1f)
-                )
-                SecondaryTile(
-                    icon = Icons.Default.Settings,
                     label = "Settings",
                     enabled = true,
                     onClick = { vm.openSettings() },
+                    modifier = Modifier.weight(1f)
+                )
+            }
+            Spacer(Modifier.height(10.dp))
+            Row(
+                Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                SecondaryTile(
+                    icon = Icons.Default.Settings,
+                    label = "API Setup",
+                    enabled = true,
+                    onClick = { vm.backToApiSetup() },
                     modifier = Modifier.weight(1f)
                 )
             }


### PR DESCRIPTION
## Summary
Three small polish fixes batched into one PR.

- **#50** — Title screen bottom row was three tiles (Graveyard / API Setup / Settings) which forced labels onto two lines after the M6 Settings tile was added. Split into two rows: Graveyard + Settings (most-used) on one row, API Setup full-width on its own row. All labels now fit on one line.
- **#51** — Replace the full-width "Randomize Everything" ``OutlinedButton`` on character creation with a glyph-only ``FilledIconButton`` (``Icons.Default.Casino`` — die), inline with the descriptive blurb.
- **#52** — Replace the Recommended ``AssistChip`` in the Stats step with a glyph-only ``FilledIconButton`` (``Icons.Default.Star``).

``contentDescription`` is set on both icon buttons for accessibility.

Fixes #50, fixes #51, fixes #52.

## Test plan
- [x] ``gradle assembleDebug`` clean
- [x] Debug-bridge P0 + P1
- [x] Title screen — labels all one line, layout reads cleanly (screenshot verified)
- [x] Character creation Step 1 — die icon top-right, blurb to its left (screenshot verified)
- [x] ``/tap contentDesc=Randomize everything`` rolls full character → lands on Step 6 Confirm
- [x] Character creation Step 5 — star icon top-right of STATS row (screenshot verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)